### PR TITLE
Fixed issue in AWS Bedrock session token

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1567,7 +1567,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			this.customGetSecret("openRouterApiKey") as Promise<string | undefined>,
 			this.customGetSecret("awsAccessKey") as Promise<string | undefined>,
 			this.customGetSecret("awsSecretKey") as Promise<string | undefined>,
-			this.customGetSecret("awsSessionToken") as Promise<string | undefined>,
+			this.customGetSecret("awsSessionToken", false) as Promise<string | undefined>,
 			this.customGetState("awsRegion") as Promise<string | undefined>,
 			this.customGetState("awsUseCrossRegionInference") as Promise<boolean | undefined>,
 			this.customGetState("vertexProjectId") as Promise<string | undefined>,
@@ -1598,7 +1598,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			this.customGetState("embeddingModelId") as Promise<string | undefined>,
 			this.customGetSecret("embeddingAwsAccessKey") as Promise<string | undefined>,
 			this.customGetSecret("embeddingAwsSecretKey") as Promise<string | undefined>,
-			this.customGetSecret("embeddingAwsSessionToken") as Promise<string | undefined>,
+			this.customGetSecret("embeddingAwsSessionToken", false) as Promise<string | undefined>,
 			this.customGetState("embeddingAwsRegion") as Promise<string | undefined>,
 			this.customGetState("embeddingOpenAiBaseUrl") as Promise<string | undefined>,
 			this.customGetSecret("embeddingOpenAiApiKey") as Promise<string | undefined>,
@@ -1758,8 +1758,12 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 		await this.storeSecret(`${this.workspaceId}-${key}` as SecretKey, value)
 	}
 
-	async customGetSecret(key: SecretKey) {
+	async customGetSecret(key: SecretKey, defaultGlobal: boolean = true) {
 		let workspaceSecret = await this.getSecret(`${this.workspaceId}-${key}` as SecretKey)
+		if (!defaultGlobal) {
+			return workspaceSecret;
+		}
+
 		if (!workspaceSecret) {
 			return await this.getSecret(key as SecretKey)
 		}

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -305,7 +305,7 @@ const ApiOptions = ({ showModelOptions, showModelError = true, apiErrorMessage, 
 						style={{ width: "100%" }}
 						type="password"
 						onInput={handleInputChange("awsSessionToken")}
-						placeholder="Enter Session Token...">
+						placeholder="Enter Session Token (optional)...">
 						<span style={{ fontWeight: 500 }}>AWS Session Token</span>
 					</VSCodeTextField>
 					<div className="dropdown-container">


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)

### Screenshots

![image](https://github.com/user-attachments/assets/4196e880-aa1d-4fbe-be4b-10298911fa26)
![image](https://github.com/user-attachments/assets/457ebe49-bc06-4f97-b801-72d60db36288)

### Additional Notes

Issue Reason: We are storing all the credentials in both the global and workspace secrets. When the credentials are not found in the workspace, it defaults to the global value.

Fix: For optional parameters like the session token, I added logic to read only from the workspace secrets.