### PR TITLE
Fixed extension host termination issue

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -142,9 +142,10 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 		this.codeIndexAbortController = new AbortController()
 		this.isSideBar = isSideBar
 		this.vsCodeWorkSpaceFolderFsPath = this.getWorkspacePath() || ""
-		if(this.vsCodeWorkSpaceFolderFsPath && this.vsCodeWorkSpaceFolderFsPath.trim() !== '') {
-		this.fileSystemWatcher = new HaiFileSystemWatcher(this, this.vsCodeWorkSpaceFolderFsPath)
-		this.codeIndexBackground()
+		this.vsCodeWorkSpaceFolderFsPath = this.vsCodeWorkSpaceFolderFsPath.trim();
+		if (this.vsCodeWorkSpaceFolderFsPath) {
+			this.fileSystemWatcher = new HaiFileSystemWatcher(this, this.vsCodeWorkSpaceFolderFsPath)
+			this.codeIndexBackground()
 		}
 	}
 

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -128,7 +128,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 
 	private codeIndexAbortController: AbortController
 	private isSideBar: boolean
-	fileSystemWatcher: HaiFileSystemWatcher
+	fileSystemWatcher: HaiFileSystemWatcher | undefined
 
 	constructor(
 		readonly context: vscode.ExtensionContext,
@@ -142,8 +142,10 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 		this.codeIndexAbortController = new AbortController()
 		this.isSideBar = isSideBar
 		this.vsCodeWorkSpaceFolderFsPath = this.getWorkspacePath() || ""
+		if(this.vsCodeWorkSpaceFolderFsPath && this.vsCodeWorkSpaceFolderFsPath.trim() !== '') {
 		this.fileSystemWatcher = new HaiFileSystemWatcher(this, this.vsCodeWorkSpaceFolderFsPath)
 		this.codeIndexBackground()
+		}
 	}
 
 	private getWorkspacePath() {
@@ -437,7 +439,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 		this.workspaceTracker = undefined
 		this.mcpHub?.dispose()
 		this.mcpHub = undefined
-		this.fileSystemWatcher.dispose()
+		this.fileSystemWatcher?.dispose()
 		this.outputChannel.appendLine("Disposed all disposables")
 		ClineProvider.activeInstances.delete(this)
 	}

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -141,8 +141,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 		this.mcpHub = new McpHub(this)
 		this.codeIndexAbortController = new AbortController()
 		this.isSideBar = isSideBar
-		this.vsCodeWorkSpaceFolderFsPath = this.getWorkspacePath() || ""
-		this.vsCodeWorkSpaceFolderFsPath = this.vsCodeWorkSpaceFolderFsPath.trim();
+		this.vsCodeWorkSpaceFolderFsPath = (this.getWorkspacePath() || "").trim()
 		if (this.vsCodeWorkSpaceFolderFsPath) {
 			this.fileSystemWatcher = new HaiFileSystemWatcher(this, this.vsCodeWorkSpaceFolderFsPath)
 			this.codeIndexBackground()


### PR DESCRIPTION
### Description

## Added validation for workspace folder path

- After retrieving the workspace folder path, a condition is added to verify its presence. If the condition is met, the File Watcher is initialized, as passing an empty value to the File Watcher leads this issues.

- Additionally, the codeIndexBackground function is brought under this condition, as invoking it without a valid workspace folder path serves no purpose.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)

