### PR TITLE
Removed Open VSX Registry publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,12 +50,11 @@ jobs:
               run: npm run build
 
             - name: Install Publishing Tools
-              run: npm install -g vsce ovsx
+              run: npm install -g vsce
 
             - name: Package and Publish Extension
               env:
                   VSCE_PAT: ${{ secrets.VSCE_PAT }}
-                  OVSX_PAT: ${{ secrets.OVSX_PAT }}
               run: |
                   current_package_version=$(node -p "require('./package.json').version")
                   npm run publish:marketplace

--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
 		"start:webview": "cd webview-ui && npm run start",
 		"build:webview": "cd webview-ui && npm run build",
 		"test:webview": "cd webview-ui && npm run test",
-		"publish:marketplace": "vsce publish && ovsx publish",
+		"publish:marketplace": "vsce publish",
 		"prepare": "husky"
 	},
 	"devDependencies": {


### PR DESCRIPTION
### Description

Removed Open VSX Registry publish, can be added later based on the internal discussion

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)
