### PR TITLE
Fixed LLM and embedding validation occurs for every indexing update

### DIFF
--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -8,7 +8,7 @@ import {
 	VSCodeTextField,
 } from "@vscode/webview-ui-toolkit/react"
 import { Fragment, memo, useCallback, useEffect, useMemo, useState } from "react"
-import { useDebounce, useEvent, useInterval } from "react-use"
+import { useDebounce, useDeepCompareEffect, useEvent, useInterval } from "react-use"
 import {
 	ApiConfiguration,
 	ApiProvider,
@@ -104,7 +104,7 @@ const ApiOptions = ({
 		setApiConfiguration(newApiConfiguration)
 	}
 
-	useEffect(() => {
+	useDeepCompareEffect(() => {
 		const error = validateApiConfiguration(apiConfiguration)
 		if (!error) {
 			setValidateLLM(apiConfiguration)

--- a/webview-ui/src/components/settings/EmbeddingOptions.tsx
+++ b/webview-ui/src/components/settings/EmbeddingOptions.tsx
@@ -13,7 +13,7 @@ import {
 import { useExtensionState } from "../../context/ExtensionStateContext"
 import { vscode } from "../../utils/vscode"
 import { ExtensionMessage } from "../../../../src/shared/ExtensionMessage"
-import { useDebounce, useEvent } from "react-use"
+import { useDebounce, useDeepCompareEffect, useEvent } from "react-use"
 import Info, { InfoStatus } from "../common/Info"
 import { validateEmbeddingConfiguration } from "../../utils/validate"
 
@@ -75,7 +75,7 @@ const EmbeddingOptions = ({ showModelOptions, showModelError = true, errorMessag
 		setEmbeddingConfiguration(newEmbeddingConfiguration)
 	}
 
-	useEffect(() => {
+	useDeepCompareEffect(() => {
 		const error = validateEmbeddingConfiguration(embeddingConfiguration)
 		if (!error) {
 			setValidateEmbedding(embeddingConfiguration)


### PR DESCRIPTION
### Description

## Replaced useEffect() with useDeepCompareEffect()

- useDeepCompareEffect performs a deep equality check on dependencies, preventing effect re-runs when object references change but the content remains the same.
- Validation now only occurs when the actual configuration values change, not during unrelated state updates.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)