### PR TITLE
Fix permissions issue in release-dev.yml and release.yml for reusable workflow

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -5,6 +5,12 @@ on:
         branches: [main]
     workflow_dispatch:
 
+permissions:
+    contents: write
+    packages: write
+    checks: write
+    pull-requests: write
+
 jobs:
     test:
         uses: ./.github/workflows/test.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,12 @@ on:
             - "v*"
     workflow_dispatch:
 
+permissions:
+    contents: write
+    packages: write
+    checks: write
+    pull-requests: write
+
 jobs:
     test:
         uses: ./.github/workflows/test.yml


### PR DESCRIPTION
### Description

Added the following permissions to development and marketplace releases.
- `contents: write`, `packages: write`, `checks: write`, and `pull-requests: write`.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)

