### PR TITLE
Fix: Update GitHub Actions workflow with correct environment variables and artifact upload paths

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -55,13 +55,13 @@ jobs:
               run: |
                   echo "PACKAGE_NAME=$(node -p "require('./package.json').name || 'hai-build-code-generator'")" >> $GITHUB_ENV
                   echo "BUILD_VERSION=$(node -p "require('./package.json').version || '0.0.0'")" >> $GITHUB_ENV
-                  npx @vscode/vsce package --out ${{ github.workspace }}/${{ env.PACKAGE_NAME }}-${{ env.BUILD_VERSION }}.vsix
+                  npx @vscode/vsce package --out "$PACKAGE_NAME-${BUILD_VERSION}.vsix"
 
             - name: Upload artifact
               uses: actions/upload-artifact@v4
               with:
                   name: vsix-package
-                  path: ${{ github.workspace }}/${{ env.PACKAGE_NAME }}-${{ env.BUILD_VERSION }}.vsix
+                  path: ${{ env.PACKAGE_NAME }}-${{ env.BUILD_VERSION }}.vsix
                   retention-days: 90
 
             - name: Notify release

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -69,7 +69,7 @@ jobs:
               uses: actions/upload-artifact@v4
               with:
                   name: vsix-package
-                  path: $PACKAGE_NAME-$BUILD_VERSION.vsix
+                  path: "${{ env.PACKAGE_NAME }}-${{ env.BUILD_VERSION }}.vsix"
                   retention-days: 90
 
             - name: Notify release

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -51,9 +51,6 @@ jobs:
               if: steps.webview-cache.outputs.cache-hit != 'true'
               run: cd webview-ui && npm ci
 
-            - name: Build Extension
-              run: npm run build
-
             - name: Build package
               run: |
                   echo "PACKAGE_NAME=$(node -p "require('./package.json').name || 'hai-build-code-generator'")" >> $GITHUB_ENV

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -68,7 +68,7 @@ jobs:
             - name: Upload artifact
               uses: actions/upload-artifact@v4
               with:
-                  name: vsix-package
+                  name: "${{ env.PACKAGE_NAME }}-${{ env.BUILD_VERSION }}"
                   path: "${{ env.PACKAGE_NAME }}-${{ env.BUILD_VERSION }}.vsix"
                   retention-days: 90
 
@@ -139,18 +139,13 @@ jobs:
                             },
                             {
                               \"type\": \"TextBlock\",
-                              \"text\": \"Release - v${{ needs.initialize.outputs.package_name }}:${{ needs.initialize.outputs.build_version }}\",
+                              \"text\": \"Release - v${{ env.BUILD_VERSION }}\",
                               \"weight\": \"Bolder\",
                               \"size\": \"Medium\"
                             },
                             {
                               \"type\": \"TextBlock\",
                               \"text\": \"🎉 The latest release is now available!\",
-                              \"wrap\": true
-                            },
-                            {
-                              \"type\": \"TextBlock\",
-                              \"text\": \"Download the artifact from: $ARTIFACT_URL\",
                               \"wrap\": true
                             },
                             {

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -51,20 +51,20 @@ jobs:
               if: steps.webview-cache.outputs.cache-hit != 'true'
               run: cd webview-ui && npm ci
 
-            - name: Set environment variables
-              run: |
-                echo "PACKAGE_NAME=$(node -p "require('./package.json').name || 'hai-build-code-generator'")" >> $GITHUB_ENV
-                echo "BUILD_VERSION=$(node -p "require('./package.json').version || '0.0.0'")" >> $GITHUB_ENV
-
             - name: Build package
               run: |
-                  npx @vscode/vsce package --out "${{ env.PACKAGE_NAME }}-${{ env.BUILD_VERSION }}.vsix"
+                  PACKAGE_NAME=$(node -p "require('./package.json').name || 'hai-build-code-generator'")
+                  echo "PACKAGE_NAME=$PACKAGE_NAME" >> $GITHUB_ENV
+                  BUILD_VERSION=$(node -p "require('./package.json').version || '0.0.0'")
+                  echo "BUILD_VERSION=$BUILD_VERSION >> $GITHUB_ENV
+                  echo "Output Package Name: $PACKAGE_NAME-$BUILD_VERSION.vsix"
+                  npx @vscode/vsce package --out "$PACKAGE_NAME-$BUILD_VERSION.vsix"
 
             - name: Upload artifact
               uses: actions/upload-artifact@v4
               with:
                   name: vsix-package
-                  path: ${{ env.PACKAGE_NAME }}-${{ env.BUILD_VERSION }}.vsix
+                  path: $PACKAGE_NAME-$BUILD_VERSION.vsix
                   retention-days: 90
 
             - name: Notify release

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -51,11 +51,14 @@ jobs:
               if: steps.webview-cache.outputs.cache-hit != 'true'
               run: cd webview-ui && npm ci
 
+            - name: Set environment variables
+              run: |
+                echo "PACKAGE_NAME=$(node -p "require('./package.json').name || 'hai-build-code-generator'")" >> $GITHUB_ENV
+                echo "BUILD_VERSION=$(node -p "require('./package.json').version || '0.0.0'")" >> $GITHUB_ENV
+
             - name: Build package
               run: |
-                  echo "PACKAGE_NAME=$(node -p "require('./package.json').name || 'hai-build-code-generator'")" >> $GITHUB_ENV
-                  echo "BUILD_VERSION=$(node -p "require('./package.json').version || '0.0.0'")" >> $GITHUB_ENV
-                  npx @vscode/vsce package --out "$PACKAGE_NAME-${BUILD_VERSION}.vsix"
+                  npx @vscode/vsce package --out "${{ env.PACKAGE_NAME }}-${{ env.BUILD_VERSION }}.vsix"
 
             - name: Upload artifact
               uses: actions/upload-artifact@v4

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -53,10 +53,15 @@ jobs:
 
             - name: Build package
               run: |
-                  PACKAGE_NAME=$(node -p "require('./package.json').name || 'hai-build-code-generator'")
+                  # Set the package name and version from package.json or use default values
+                  PACKAGE_NAME="$(node -p "require('./package.json').name || 'hai-build-code-generator'")"
+                  BUILD_VERSION="$(node -p "require('./package.json').version || '0.0.0'")"
+
+                  # Save the environment variables to GitHub Actions environment
                   echo "PACKAGE_NAME=$PACKAGE_NAME" >> $GITHUB_ENV
-                  BUILD_VERSION=$(node -p "require('./package.json').version || '0.0.0'")
-                  echo "BUILD_VERSION=$BUILD_VERSION >> $GITHUB_ENV
+                  echo "BUILD_VERSION=$BUILD_VERSION" >> $GITHUB_ENV
+
+                  # Build the VSIX package
                   echo "Output Package Name: $PACKAGE_NAME-$BUILD_VERSION.vsix"
                   npx @vscode/vsce package --out "$PACKAGE_NAME-$BUILD_VERSION.vsix"
 

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -55,7 +55,7 @@ jobs:
               run: |
                   echo "PACKAGE_NAME=$(node -p "require('./package.json').name || 'hai-build-code-generator'")" >> $GITHUB_ENV
                   echo "BUILD_VERSION=$(node -p "require('./package.json').version || '0.0.0'")" >> $GITHUB_ENV
-                  npx @vscode/vsce package --out "$PACKAGE_NAME-$BUILD_VERSION.vsix"
+                  npx @vscode/vsce package --out ${{ github.workspace }}/${{ env.PACKAGE_NAME }}-${{ env.BUILD_VERSION }}.vsix
 
             - name: Upload artifact
               uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,6 @@ jobs:
               if: steps.webview-cache.outputs.cache-hit != 'true'
               run: cd webview-ui && npm ci
 
-            - name: Build Extension
-              run: npm run build
-
             - name: Install Publishing Tools
               run: npm install -g vsce
 


### PR DESCRIPTION
### Description

This pull request updates the GitHub Actions workflows by fixing the environment variable setting, packaging process, and artifact upload paths. The following updates have been made:

1. Removed unnecessary npm build in `release-dev.yml and release.yml`.
2. Corrected the environment variable setting for `PACKAGE_NAME` and `BUILD_VERSION` to ensure they are correctly picked up for the packaging process.
3. Updated the artifact upload step to properly reference the generated VSIX file using the environment variables.


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [X] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [X] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)

