### PR TITLE
Fixed undefined issue in custom instructions

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1729,6 +1729,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			chatSettings,
 			isLoggedIn: !!authToken,
 			userInfo,
+			vscodeWorkspacePath: this.vsCodeWorkSpaceFolderFsPath,
 		}
 	}
 

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -84,6 +84,7 @@ export interface ExtensionState {
 	buildContextOptions?: HaiBuildContextOptions
 	buildIndexProgress?: HaiBuildIndexProgress
 	embeddingConfiguration?: EmbeddingConfiguration
+	vscodeWorkspacePath?: string
 }
 
 export interface ClineMessage {

--- a/webview-ui/src/components/chat/CustomInstructionsMenu.tsx
+++ b/webview-ui/src/components/chat/CustomInstructionsMenu.tsx
@@ -122,12 +122,11 @@ const CustomInstructionsMenu = ({ isExpanded, onToggleExpand }: CustomInstructio
 						}}>
 						{(fileInstructions ?? []).filter((i) => i.enabled).length > 0 ||
 						(customInstructions && isCustomInstructionsEnabled)
-							? `${fileInstructions
-									?.filter((i) => i.enabled)
+							? `${(fileInstructions ?? [])
 									.filter((i) => i.enabled)
 									.map((i) => i.name)
 									.join(", ")}${
-									(fileInstructions?.filter((i) => i.enabled).length ?? 0) > 0 &&
+									((fileInstructions ?? []).filter((i) => i.enabled).length ?? 0) > 0 &&
 									customInstructions &&
 									isCustomInstructionsEnabled
 										? ", "

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -29,6 +29,7 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 		embeddingConfiguration,
 		fileInstructions,
 		setFileInstructions,
+		vscodeWorkspacePath,
 	} = useExtensionState()
 	const [apiErrorMessage, setApiErrorMessage] = useState<string | undefined>(undefined)
 	const [modelIdErrorMessage, setModelIdErrorMessage] = useState<string | undefined>(undefined)
@@ -212,7 +213,8 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 						resize="vertical"
 						rows={4}
 						placeholder={'e.g. "Run unit tests at the end", "Use TypeScript with async/await", "Speak in Spanish"'}
-						onInput={(e: any) => setCustomInstructions(e.target?.value ?? "")}>
+						onInput={(e: any) => setCustomInstructions(e.target?.value ?? "")}
+						disabled={!vscodeWorkspacePath}>
 						<span style={{ fontWeight: "500" }}>Custom Instructions</span>
 					</VSCodeTextArea>
 					<p
@@ -231,7 +233,8 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 							alignItems: "center",
 							justifyContent: "center",
 						}}
-						onClick={() => document.getElementById("fileInput")?.click()}>
+						onClick={() => document.getElementById("fileInput")?.click()}
+						disabled={!vscodeWorkspacePath}>
 						<span className="codicon codicon-add" style={{ marginRight: "5px" }}></span>
 						Upload Instruction File
 					</VSCodeButton>
@@ -306,7 +309,11 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 					</p>
 				</div>
 
-				<SettingsViewExtra setBuildContextOptions={setBuildContextOptions} buildContextOptions={buildContextOptions} />
+				<SettingsViewExtra
+					setBuildContextOptions={setBuildContextOptions}
+					buildContextOptions={buildContextOptions}
+					vscodeWorkspacePath={vscodeWorkspacePath}
+				/>
 
 				{IS_DEV && (
 					<>

--- a/webview-ui/src/components/settings/SettingsViewExtra.tsx
+++ b/webview-ui/src/components/settings/SettingsViewExtra.tsx
@@ -54,10 +54,11 @@ const IndexingProgress = memo(({ buildContextOptions }: IndexingProgressProps) =
 
 type SettingsViewExtraProps = {
 	buildContextOptions?: HaiBuildContextOptions
+	vscodeWorkspacePath?: string
 	setBuildContextOptions: (value: HaiBuildContextOptions) => void
 }
 
-const SettingsViewExtra = ({ buildContextOptions, setBuildContextOptions }: SettingsViewExtraProps) => {
+const SettingsViewExtra = ({ buildContextOptions, vscodeWorkspacePath, setBuildContextOptions }: SettingsViewExtraProps) => {
 	return (
 		<>
 			<div style={{ marginBottom: 5 }}>
@@ -68,7 +69,8 @@ const SettingsViewExtra = ({ buildContextOptions, setBuildContextOptions }: Sett
 							...buildContextOptions!,
 							useIndex: e.target?.checked,
 						})
-					}}>
+					}}
+					disabled={!vscodeWorkspacePath}>
 					<span style={{ fontWeight: "500" }}>Use Code Index</span>
 				</VSCodeCheckbox>
 				<IndexingProgress buildContextOptions={buildContextOptions} />
@@ -86,7 +88,7 @@ const SettingsViewExtra = ({ buildContextOptions, setBuildContextOptions }: Sett
 			<div style={{ marginBottom: 5 }}>
 				<VSCodeCheckbox
 					checked={buildContextOptions?.useContext}
-					disabled={!buildContextOptions?.useIndex}
+					disabled={!vscodeWorkspacePath || !buildContextOptions?.useIndex}
 					onChange={(e: any) => {
 						setBuildContextOptions({
 							...buildContextOptions!,
@@ -110,7 +112,7 @@ const SettingsViewExtra = ({ buildContextOptions, setBuildContextOptions }: Sett
 					value={buildContextOptions?.appContext ?? ""}
 					style={{ width: "100%" }}
 					rows={4}
-					disabled={!buildContextOptions?.useIndex}
+					disabled={!vscodeWorkspacePath || !buildContextOptions?.useIndex}
 					placeholder={'e.g. "This is an e-commerce application", "This is an CRM application"'}
 					onInput={(e: any) => {
 						setBuildContextOptions({
@@ -135,7 +137,7 @@ const SettingsViewExtra = ({ buildContextOptions, setBuildContextOptions }: Sett
 					value={buildContextOptions?.excludeFolders ?? ""}
 					style={{ width: "100%" }}
 					rows={4}
-					disabled={!buildContextOptions?.useIndex}
+					disabled={!vscodeWorkspacePath || !buildContextOptions?.useIndex}
 					placeholder={"Comma separated list of folders to exclude from indexing"}
 					onInput={(e: any) => {
 						setBuildContextOptions({


### PR DESCRIPTION
### Description

- Fixed custom instructions showing "undefined" when vscode is opened without a workspace
- Disabled custom instructions, code context, code indexing when no workspace is opened

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)

### Screenshots

![image](https://github.com/user-attachments/assets/171b67a6-b27a-4f35-832f-cca5ae77286d)