### PR TITLE
Could not import faiss-node

### DIFF
--- a/src/utils/runtime-downloader.ts
+++ b/src/utils/runtime-downloader.ts
@@ -66,7 +66,7 @@ export async function downloadFile(
 }
 
 export async function unzip(zipFile: string, destinationDir: string): Promise<void> {
-	extract({
+	await extract({
 		file: zipFile,
 		cwd: destinationDir,
 	})


### PR DESCRIPTION
### Description

- Added `await` to the extraction of the faiss-node build to prevent potential issues where indexing might occur before the extraction is complete.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)
