### PR TITLE
Fixed multiple code indexing background tasks being triggered

### DIFF
--- a/.changeset/friendly-masks-marry.md
+++ b/.changeset/friendly-masks-marry.md
@@ -1,0 +1,5 @@
+---
+"hai-build-code-generator": patch
+---
+
+Fixed multiple code indexing background tasks being triggered.


### PR DESCRIPTION
### Description

Added a flag to prevent code indexing from being triggered multiple times simultaneously, which may be causing users to encounter limit exceeded errors even for smaller project sizes.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)
