### PR TITLE
Autosave settings

### DIFF
--- a/.changeset/weak-geckos-turn.md
+++ b/.changeset/weak-geckos-turn.md
@@ -1,0 +1,5 @@
+---
+"hai-build-code-generator": patch
+---
+
+Added autosave settings

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "hai-build-code-generator",
-	"version": "3.0.2",
+	"version": "3.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "hai-build-code-generator",
-			"version": "3.0.2",
+			"version": "3.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@anthropic-ai/bedrock-sdk": "^0.10.2",

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -15,7 +15,7 @@ import { getTheme } from "../../integrations/theme/getTheme"
 import WorkspaceTracker from "../../integrations/workspace/WorkspaceTracker"
 import { McpHub } from "../../services/mcp/McpHub"
 import { FirebaseAuthManager, UserInfo } from "../../services/auth/FirebaseAuthManager"
-import { ApiProvider, ModelInfo } from "../../shared/api"
+import { ApiConfiguration, ApiProvider, ModelInfo } from "../../shared/api"
 import { findLast } from "../../shared/array"
 import { ExtensionMessage, ExtensionState } from "../../shared/ExtensionMessage"
 import { HistoryItem } from "../../shared/HistoryItem"
@@ -33,7 +33,7 @@ import { CodeContextErrorMessage, CodeIndexStartMessage } from "./customClientPr
 import { ICodeIndexProgress } from "../../integrations/code-prep/type"
 import { validateApiConfiguration, validateEmbeddingConfiguration } from "../../shared/validate"
 import { getFormattedDateTime } from "../../utils/date"
-import { EmbeddingProvider } from "../../shared/embeddings"
+import { EmbeddingConfiguration, EmbeddingProvider } from "../../shared/embeddings"
 import { ensureFaissPlatformDeps } from "../../utils/faiss"
 import { ACCEPTED_FILE_EXTENSIONS, FileOperations } from "../../utils/constants"
 import HaiFileSystemWatcher from "../../integrations/workspace/HaiFileSystemWatcher"
@@ -766,6 +766,113 @@ export class ClineProvider implements vscode.WebviewViewProvider {
       `
 	}
 
+	private async updateApiConfiguration(apiConfiguration: ApiConfiguration) {
+		const {
+			apiProvider,
+			apiModelId,
+			apiKey,
+			openRouterApiKey,
+			awsAccessKey,
+			awsSecretKey,
+			awsSessionToken,
+			awsRegion,
+			awsUseCrossRegionInference,
+			vertexProjectId,
+			vertexRegion,
+			openAiBaseUrl,
+			openAiApiKey,
+			openAiModelId,
+			ollamaModelId,
+			ollamaBaseUrl,
+			lmStudioModelId,
+			lmStudioBaseUrl,
+			anthropicBaseUrl,
+			geminiApiKey,
+			openAiNativeApiKey,
+			deepSeekApiKey,
+			mistralApiKey,
+			azureApiVersion,
+			openRouterModelId,
+			openRouterModelInfo,
+			vsCodeLmModelSelector,
+			liteLlmBaseUrl,
+			liteLlmModelId,
+		} = apiConfiguration
+		await this.customUpdateState("apiProvider", apiProvider)
+		await this.customUpdateState("apiModelId", apiModelId)
+		await this.customStoreSecret("apiKey", apiKey, true)
+		await this.customStoreSecret("openRouterApiKey", openRouterApiKey, true)
+		await this.customStoreSecret("awsAccessKey", awsAccessKey, true)
+		await this.customStoreSecret("awsSecretKey", awsSecretKey, true)
+		await this.customStoreSecret("awsSessionToken", awsSessionToken, true)
+		await this.customUpdateState("awsRegion", awsRegion)
+		await this.customUpdateState("awsUseCrossRegionInference", awsUseCrossRegionInference)
+		await this.customUpdateState("vertexProjectId", vertexProjectId)
+		await this.customUpdateState("vertexRegion", vertexRegion)
+		await this.customUpdateState("openAiBaseUrl", openAiBaseUrl)
+		await this.customStoreSecret("openAiApiKey", openAiApiKey, true)
+		await this.customUpdateState("openAiModelId", openAiModelId)
+		await this.customUpdateState("ollamaModelId", ollamaModelId)
+		await this.customUpdateState("ollamaBaseUrl", ollamaBaseUrl)
+		await this.customUpdateState("lmStudioModelId", lmStudioModelId)
+		await this.customUpdateState("lmStudioBaseUrl", lmStudioBaseUrl)
+		await this.customUpdateState("anthropicBaseUrl", anthropicBaseUrl)
+		await this.customStoreSecret("geminiApiKey", geminiApiKey, true)
+		await this.customStoreSecret("openAiNativeApiKey", openAiNativeApiKey, true)
+		await this.customStoreSecret("deepSeekApiKey", deepSeekApiKey, true)
+		await this.customStoreSecret("mistralApiKey", mistralApiKey, true)
+		await this.customUpdateState("azureApiVersion", azureApiVersion)
+		await this.customUpdateState("openRouterModelId", openRouterModelId)
+		await this.customUpdateState("openRouterModelInfo", openRouterModelInfo)
+		await this.customUpdateState("vsCodeLmModelSelector", vsCodeLmModelSelector)
+		await this.updateGlobalState("liteLlmBaseUrl", liteLlmBaseUrl)
+		await this.updateGlobalState("liteLlmModelId", liteLlmModelId)
+		if (this.cline) {
+			this.cline.api = buildApiHandler(apiConfiguration)
+		}
+	}
+
+	private async updateEmbeddingConfiguration(embeddingConfiguration: EmbeddingConfiguration) {
+		const {
+			provider,
+			modelId,
+			awsAccessKey,
+			awsSecretKey,
+			awsSessionToken,
+			awsRegion,
+			openAiBaseUrl,
+			openAiModelId,
+			openAiApiKey,
+			openAiNativeApiKey,
+			azureOpenAIApiKey,
+			azureOpenAIApiInstanceName,
+			azureOpenAIApiEmbeddingsDeploymentName,
+			azureOpenAIApiVersion,
+			ollamaBaseUrl,
+			ollamaModelId,
+		} = embeddingConfiguration
+
+		// Update Global State
+		await this.customUpdateState("embeddingProvider", provider)
+		await this.customUpdateState("embeddingModelId", modelId)
+		await this.customUpdateState("embeddingAwsRegion", awsRegion)
+		await this.customUpdateState("embeddingOpenAiBaseUrl", openAiBaseUrl)
+		await this.customUpdateState("embeddingOpenAiModelId", openAiModelId)
+		await this.customUpdateState("embeddingAzureOpenAIApiInstanceName", azureOpenAIApiInstanceName)
+		await this.customUpdateState("embeddingAzureOpenAIApiVersion", azureOpenAIApiVersion)
+		await this.customUpdateState("embeddingAzureOpenAIApiEmbeddingsDeploymentName", azureOpenAIApiEmbeddingsDeploymentName)
+		await this.customUpdateState("embeddingOllamaBaseUrl", ollamaBaseUrl)
+		await this.customUpdateState("embeddingOllamaModelId", ollamaModelId)
+		// Update Secrets
+		await this.customStoreSecret("embeddingAwsAccessKey", awsAccessKey, true)
+		await this.customStoreSecret("embeddingAwsSecretKey", awsSecretKey, true)
+		await this.customStoreSecret("embeddingAwsSecretKey", awsSecretKey, true)
+		await this.customStoreSecret("embeddingAwsSessionToken", awsSessionToken, true)
+		await this.customStoreSecret("embeddingOpenAiApiKey", openAiApiKey, true)
+		await this.customStoreSecret("embeddingOpenAiNativeApiKey", openAiNativeApiKey, true)
+		await this.customStoreSecret("embeddingAzureOpenAIApiKey", azureOpenAIApiKey, true)
+	}
+
 	/**
 	 * Sets up an event listener to listen for messages passed from the webview context and
 	 * executes code based on the message that is recieved.
@@ -825,69 +932,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 						break
 					case "apiConfiguration":
 						if (message.apiConfiguration) {
-							const {
-								apiProvider,
-								apiModelId,
-								apiKey,
-								openRouterApiKey,
-								awsAccessKey,
-								awsSecretKey,
-								awsSessionToken,
-								awsRegion,
-								awsUseCrossRegionInference,
-								vertexProjectId,
-								vertexRegion,
-								openAiBaseUrl,
-								openAiApiKey,
-								openAiModelId,
-								ollamaModelId,
-								ollamaBaseUrl,
-								lmStudioModelId,
-								lmStudioBaseUrl,
-								anthropicBaseUrl,
-								geminiApiKey,
-								openAiNativeApiKey,
-								deepSeekApiKey,
-								mistralApiKey,
-								azureApiVersion,
-								openRouterModelId,
-								openRouterModelInfo,
-								vsCodeLmModelSelector,
-								liteLlmBaseUrl,
-								liteLlmModelId,
-							} = message.apiConfiguration
-							await this.customUpdateState("apiProvider", apiProvider)
-							await this.customUpdateState("apiModelId", apiModelId)
-							await this.customStoreSecret("apiKey", apiKey)
-							await this.customStoreSecret("openRouterApiKey", openRouterApiKey)
-							await this.customStoreSecret("awsAccessKey", awsAccessKey)
-							await this.customStoreSecret("awsSecretKey", awsSecretKey)
-							await this.customStoreSecret("awsSessionToken", awsSessionToken)
-							await this.customUpdateState("awsRegion", awsRegion)
-							await this.customUpdateState("awsUseCrossRegionInference", awsUseCrossRegionInference)
-							await this.customUpdateState("vertexProjectId", vertexProjectId)
-							await this.customUpdateState("vertexRegion", vertexRegion)
-							await this.customUpdateState("openAiBaseUrl", openAiBaseUrl)
-							await this.customStoreSecret("openAiApiKey", openAiApiKey)
-							await this.customUpdateState("openAiModelId", openAiModelId)
-							await this.customUpdateState("ollamaModelId", ollamaModelId)
-							await this.customUpdateState("ollamaBaseUrl", ollamaBaseUrl)
-							await this.customUpdateState("lmStudioModelId", lmStudioModelId)
-							await this.customUpdateState("lmStudioBaseUrl", lmStudioBaseUrl)
-							await this.customUpdateState("anthropicBaseUrl", anthropicBaseUrl)
-							await this.customStoreSecret("geminiApiKey", geminiApiKey)
-							await this.customStoreSecret("openAiNativeApiKey", openAiNativeApiKey)
-							await this.customStoreSecret("deepSeekApiKey", deepSeekApiKey)
-							await this.customStoreSecret("mistralApiKey", mistralApiKey)
-							await this.customUpdateState("azureApiVersion", azureApiVersion)
-							await this.customUpdateState("openRouterModelId", openRouterModelId)
-							await this.customUpdateState("openRouterModelInfo", openRouterModelInfo)
-							await this.customUpdateState("vsCodeLmModelSelector", vsCodeLmModelSelector)
-							await this.updateGlobalState("liteLlmBaseUrl", liteLlmBaseUrl)
-							await this.updateGlobalState("liteLlmModelId", liteLlmModelId)
-							if (this.cline) {
-								this.cline.api = buildApiHandler(message.apiConfiguration)
-							}
+							await this.updateApiConfiguration(message.apiConfiguration)
 						}
 						await this.postStateToWebview()
 						break
@@ -1247,88 +1292,62 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 
 					case "embeddingConfiguration":
 						if (message.embeddingConfiguration) {
-							const {
-								provider,
-								modelId,
-								awsAccessKey,
-								awsSecretKey,
-								awsSessionToken,
-								awsRegion,
-								openAiBaseUrl,
-								openAiModelId,
-								openAiApiKey,
-								openAiNativeApiKey,
-								azureOpenAIApiKey,
-								azureOpenAIApiInstanceName,
-								azureOpenAIApiEmbeddingsDeploymentName,
-								azureOpenAIApiVersion,
-								ollamaBaseUrl,
-								ollamaModelId,
-							} = message.embeddingConfiguration
-
-							// Update Global State
-							await this.customUpdateState("embeddingProvider", provider)
-							await this.customUpdateState("embeddingModelId", modelId)
-							await this.customUpdateState("embeddingAwsRegion", awsRegion)
-							await this.customUpdateState("embeddingOpenAiBaseUrl", openAiBaseUrl)
-							await this.customUpdateState("embeddingOpenAiModelId", openAiModelId)
-							await this.customUpdateState("embeddingAzureOpenAIApiInstanceName", azureOpenAIApiInstanceName)
-							await this.customUpdateState("embeddingAzureOpenAIApiVersion", azureOpenAIApiVersion)
-							await this.customUpdateState(
-								"embeddingAzureOpenAIApiEmbeddingsDeploymentName",
-								azureOpenAIApiEmbeddingsDeploymentName,
-							)
-							await this.customUpdateState("embeddingOllamaBaseUrl", ollamaBaseUrl)
-							await this.customUpdateState("embeddingOllamaModelId", ollamaModelId)
-							// Update Secrets
-							await this.customStoreSecret("embeddingAwsAccessKey", awsAccessKey)
-							await this.customStoreSecret("embeddingAwsSecretKey", awsSecretKey)
-							await this.customStoreSecret("embeddingAwsSecretKey", awsSecretKey)
-							await this.customStoreSecret("embeddingAwsSessionToken", awsSessionToken)
-							await this.customStoreSecret("embeddingOpenAiApiKey", openAiApiKey)
-							await this.customStoreSecret("embeddingOpenAiNativeApiKey", openAiNativeApiKey)
-							await this.customStoreSecret("embeddingAzureOpenAIApiKey", azureOpenAIApiKey)
+							await this.updateEmbeddingConfiguration(message.embeddingConfiguration)
 						}
 						await this.postStateToWebview()
 						break
 					case "validateLLMConfig":
 						let isValid = false
 						if (message.apiConfiguration) {
-							try {
-								const apiHandler = buildApiHandler({ ...message.apiConfiguration, maxRetries: 0 })
-								isValid = await apiHandler.validateAPIKey()
-							} catch (error) {
-								vscode.window.showErrorMessage(`LLM validation failed: ${error}`)
+							// If no validation error is encountered, validate the LLM configuration by sending a test message.
+							if (!message.text) {
+								try {
+									const apiHandler = buildApiHandler({ ...message.apiConfiguration, maxRetries: 0 })
+									isValid = await apiHandler.validateAPIKey()
+								} catch (error) {
+									vscode.window.showErrorMessage(`LLM validation failed: ${error}`)
+								}
 							}
+
+							// Save the LLM configuration in the state
+							await this.updateApiConfiguration(message.apiConfiguration)
 						}
 
-						this.postMessageToWebview({
-							type: "llmConfigValidation",
-							bool: isValid,
-						})
+						if (!message.text) {
+							this.postMessageToWebview({
+								type: "llmConfigValidation",
+								bool: isValid,
+							})
+						}
 						await this.customUpdateState("isApiConfigurationValid", isValid)
-
 						break
 					case "validateEmbeddingConfig":
 						let isEmbeddingValid = false
 						if (message.embeddingConfiguration) {
-							try {
-								const embeddingHandler = buildEmbeddingHandler({
-									...message.embeddingConfiguration,
-									maxRetries: 0,
-								})
-								isEmbeddingValid = await embeddingHandler.validateAPIKey()
-							} catch (error) {
-								vscode.window.showErrorMessage(`Embedding validation failed: ${error}`)
+							// If no validation error is encountered, validate the Embedding configuration by sending a test message.
+							if (!message.text) {
+								try {
+									const embeddingHandler = buildEmbeddingHandler({
+										...message.embeddingConfiguration,
+										maxRetries: 0,
+									})
+									isEmbeddingValid = await embeddingHandler.validateAPIKey()
+								} catch (error) {
+									vscode.window.showErrorMessage(`Embedding validation failed: ${error}`)
+								}
 							}
+
+							// Save the Embedding configuration in the state
+							await this.updateEmbeddingConfiguration(message.embeddingConfiguration)
 						}
 
-						this.postMessageToWebview({
-							type: "embeddingConfigValidation",
-							bool: isEmbeddingValid,
-						})
+						if (!message.text) {
+							this.postMessageToWebview({
+								type: "embeddingConfigValidation",
+								bool: isEmbeddingValid,
+							})
+						}
 						await this.customUpdateState("isEmbeddingConfigurationValid", isEmbeddingValid)
-
 						break
 					case "openHistory":
 						this.postMessageToWebview({ type: "action", action: "historyButtonClicked" })

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1299,6 +1299,9 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 					case "validateLLMConfig":
 						let isValid = false
 						if (message.apiConfiguration) {
+							// Save the LLM configuration in the state
+							await this.updateApiConfiguration(message.apiConfiguration)
+
 							// If no validation error is encountered, validate the LLM configuration by sending a test message.
 							if (!message.text) {
 								try {
@@ -1308,9 +1311,6 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 									vscode.window.showErrorMessage(`LLM validation failed: ${error}`)
 								}
 							}
-
-							// Save the LLM configuration in the state
-							await this.updateApiConfiguration(message.apiConfiguration)
 						}
 
 						if (!message.text) {
@@ -1324,6 +1324,9 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 					case "validateEmbeddingConfig":
 						let isEmbeddingValid = false
 						if (message.embeddingConfiguration) {
+							// Save the Embedding configuration in the state
+							await this.updateEmbeddingConfiguration(message.embeddingConfiguration)
+
 							// If no validation error is encountered, validate the Embedding configuration by sending a test message.
 							if (!message.text) {
 								try {
@@ -1336,9 +1339,6 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 									vscode.window.showErrorMessage(`Embedding validation failed: ${error}`)
 								}
 							}
-
-							// Save the Embedding configuration in the state
-							await this.updateEmbeddingConfiguration(message.embeddingConfiguration)
 						}
 
 						if (!message.text) {

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -189,7 +189,7 @@ const AppContent = () => {
 									onStoryClick={handleStoryClick}
 								/>
 							)}
-							{showSettings && <SettingsView onDone={() => setShowSettings(false)} />}
+							{showSettings && <SettingsView />}
 							{showHistory && <HistoryView onDone={() => setShowHistory(false)} />}
 							{showMcp && <McpView onDone={() => setShowMcp(false)} />}
 							{showAccount && <AccountView onDone={() => setShowAccount(false)} />}

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1057,12 +1057,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 									style={{
 										bottom: `calc(100vh - ${menuPosition}px + 6px)`,
 									}}>
-									<ApiOptions
-										showModelOptions={true}
-										apiErrorMessage={undefined}
-										modelIdErrorMessage={undefined}
-										isPopup={true}
-									/>
+									<ApiOptions showModelOptions={true} isPopup={true} />
 								</ModelSelectorTooltip>
 							)}
 						</ModelContainer>

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -38,7 +38,7 @@ import { vscode } from "../../utils/vscode"
 import VSCodeButtonLink from "../common/VSCodeButtonLink"
 import OpenRouterModelPicker, { ModelDescriptionMarkdown } from "./OpenRouterModelPicker"
 import Info, { InfoStatus } from "../common/Info"
-import { validateApiConfiguration } from "../../utils/validate"
+import { validateApiConfiguration, validateModelId } from "../../utils/validate"
 import styled from "styled-components"
 import * as vscodemodels from "vscode"
 
@@ -75,15 +75,8 @@ declare module "vscode" {
 	}
 }
 
-const ApiOptions = ({
-	showModelOptions,
-	showModelError = true,
-	apiErrorMessage,
-	modelIdErrorMessage,
-	isPopup,
-	onValid,
-}: ApiOptionsProps) => {
-	const { apiConfiguration, setApiConfiguration, uriScheme } = useExtensionState()
+const ApiOptions = ({ showModelOptions, showModelError = true, isPopup, onValid }: ApiOptionsProps) => {
+	const { apiConfiguration, setApiConfiguration, uriScheme, openRouterModels } = useExtensionState()
 	const [ollamaModels, setOllamaModels] = useState<string[]>([])
 	const [lmStudioModels, setLmStudioModels] = useState<string[]>([])
 	const [vsCodeLmModels, setVsCodeLmModels] = useState<vscodemodels.LanguageModelChatSelector[]>([])
@@ -106,10 +99,13 @@ const ApiOptions = ({
 
 	useDeepCompareEffect(() => {
 		const error = validateApiConfiguration(apiConfiguration)
-		if (!error) {
-			setValidateLLM(apiConfiguration)
-		} else {
+		const modelIdValidationResult = validateModelId(apiConfiguration, openRouterModels)
+
+		if (error || modelIdValidationResult) {
 			setIsKeyValid(null)
+			vscode.postMessage({ type: "validateLLMConfig", apiConfiguration, text: error || modelIdValidationResult })
+		} else {
+			setValidateLLM(apiConfiguration)
 		}
 	}, [apiConfiguration])
 
@@ -252,7 +248,9 @@ const ApiOptions = ({
 						type="password"
 						onInput={handleInputChange("apiKey")}
 						placeholder="Enter API Key...">
-						<span style={{ fontWeight: 500 }}>Anthropic API Key</span>
+						<span style={{ fontWeight: 500 }}>
+							Anthropic API Key <span style={{ color: "#e8912d" }}>*</span>
+						</span>
 					</VSCodeTextField>
 
 					<VSCodeCheckbox
@@ -309,7 +307,9 @@ const ApiOptions = ({
 						type="password"
 						onInput={handleInputChange("openAiNativeApiKey")}
 						placeholder="Enter API Key...">
-						<span style={{ fontWeight: 500 }}>OpenAI API Key</span>
+						<span style={{ fontWeight: 500 }}>
+							OpenAI API Key <span style={{ color: "#e8912d" }}>*</span>
+						</span>
 					</VSCodeTextField>
 					<p
 						style={{
@@ -340,7 +340,9 @@ const ApiOptions = ({
 						type="password"
 						onInput={handleInputChange("deepSeekApiKey")}
 						placeholder="Enter API Key...">
-						<span style={{ fontWeight: 500 }}>DeepSeek API Key</span>
+						<span style={{ fontWeight: 500 }}>
+							DeepSeek API Key <span style={{ color: "#e8912d" }}>*</span>
+						</span>
 					</VSCodeTextField>
 					<p
 						style={{
@@ -371,7 +373,9 @@ const ApiOptions = ({
 						type="password"
 						onInput={handleInputChange("mistralApiKey")}
 						placeholder="Enter API Key...">
-						<span style={{ fontWeight: 500 }}>Mistral API Key</span>
+						<span style={{ fontWeight: 500 }}>
+							Mistral API Key <span style={{ color: "#e8912d" }}>*</span>
+						</span>
 					</VSCodeTextField>
 					<p
 						style={{
@@ -402,7 +406,9 @@ const ApiOptions = ({
 						type="password"
 						onInput={handleInputChange("openRouterApiKey")}
 						placeholder="Enter API Key...">
-						<span style={{ fontWeight: 500 }}>OpenRouter API Key</span>
+						<span style={{ fontWeight: 500 }}>
+							OpenRouter API Key <span style={{ color: "#e8912d" }}>*</span>
+						</span>
 					</VSCodeTextField>
 					{!apiConfiguration?.openRouterApiKey && (
 						<VSCodeButtonLink
@@ -442,7 +448,9 @@ const ApiOptions = ({
 						type="password"
 						onInput={handleInputChange("awsAccessKey")}
 						placeholder="Enter Access Key...">
-						<span style={{ fontWeight: 500 }}>AWS Access Key</span>
+						<span style={{ fontWeight: 500 }}>
+							AWS Access Key <span style={{ color: "#e8912d" }}>*</span>
+						</span>
 					</VSCodeTextField>
 					<VSCodeTextField
 						value={apiConfiguration?.awsSecretKey || ""}
@@ -450,7 +458,9 @@ const ApiOptions = ({
 						type="password"
 						onInput={handleInputChange("awsSecretKey")}
 						placeholder="Enter Secret Key...">
-						<span style={{ fontWeight: 500 }}>AWS Secret Key</span>
+						<span style={{ fontWeight: 500 }}>
+							AWS Secret Key <span style={{ color: "#e8912d" }}>*</span>
+						</span>
 					</VSCodeTextField>
 					<VSCodeTextField
 						value={apiConfiguration?.awsSessionToken || ""}
@@ -462,7 +472,9 @@ const ApiOptions = ({
 					</VSCodeTextField>
 					<DropdownContainer zIndex={DROPDOWN_Z_INDEX - 1} className="dropdown-container">
 						<label htmlFor="aws-region-dropdown">
-							<span style={{ fontWeight: 500 }}>AWS Region</span>
+							<span style={{ fontWeight: 500 }}>
+								AWS Region <span style={{ color: "#e8912d" }}>*</span>
+							</span>
 						</label>
 						<VSCodeDropdown
 							id="aws-region-dropdown"
@@ -533,11 +545,15 @@ const ApiOptions = ({
 						style={{ width: "100%" }}
 						onInput={handleInputChange("vertexProjectId")}
 						placeholder="Enter Project ID...">
-						<span style={{ fontWeight: 500 }}>Google Cloud Project ID</span>
+						<span style={{ fontWeight: 500 }}>
+							Google Cloud Project ID <span style={{ color: "#e8912d" }}>*</span>
+						</span>
 					</VSCodeTextField>
 					<DropdownContainer zIndex={DROPDOWN_Z_INDEX - 2} className="dropdown-container">
 						<label htmlFor="vertex-region-dropdown">
-							<span style={{ fontWeight: 500 }}>Google Cloud Region</span>
+							<span style={{ fontWeight: 500 }}>
+								Google Cloud Region <span style={{ color: "#e8912d" }}>*</span>
+							</span>
 						</label>
 						<VSCodeDropdown
 							id="vertex-region-dropdown"
@@ -581,7 +597,9 @@ const ApiOptions = ({
 						type="password"
 						onInput={handleInputChange("geminiApiKey")}
 						placeholder="Enter API Key...">
-						<span style={{ fontWeight: 500 }}>Gemini API Key</span>
+						<span style={{ fontWeight: 500 }}>
+							Gemini API Key <span style={{ color: "#e8912d" }}>*</span>
+						</span>
 					</VSCodeTextField>
 					<p
 						style={{
@@ -612,7 +630,9 @@ const ApiOptions = ({
 						type="url"
 						onInput={handleInputChange("openAiBaseUrl")}
 						placeholder={"Enter base URL..."}>
-						<span style={{ fontWeight: 500 }}>Base URL</span>
+						<span style={{ fontWeight: 500 }}>
+							Base URL <span style={{ color: "#e8912d" }}>*</span>
+						</span>
 					</VSCodeTextField>
 					<VSCodeTextField
 						value={apiConfiguration?.openAiApiKey || ""}
@@ -620,14 +640,18 @@ const ApiOptions = ({
 						type="password"
 						onInput={handleInputChange("openAiApiKey")}
 						placeholder="Enter API Key...">
-						<span style={{ fontWeight: 500 }}>API Key</span>
+						<span style={{ fontWeight: 500 }}>
+							API Key <span style={{ color: "#e8912d" }}>*</span>
+						</span>
 					</VSCodeTextField>
 					<VSCodeTextField
 						value={apiConfiguration?.openAiModelId || ""}
 						style={{ width: "100%" }}
 						onInput={handleInputChange("openAiModelId")}
 						placeholder={"Enter Model ID..."}>
-						<span style={{ fontWeight: 500 }}>Model ID</span>
+						<span style={{ fontWeight: 500 }}>
+							Model ID <span style={{ color: "#e8912d" }}>*</span>
+						</span>
 					</VSCodeTextField>
 					<VSCodeCheckbox
 						checked={azureApiVersionSelected}
@@ -658,7 +682,9 @@ const ApiOptions = ({
 				<div>
 					<DropdownContainer zIndex={DROPDOWN_Z_INDEX - 2} className="dropdown-container">
 						<label htmlFor="vscode-lm-model">
-							<span style={{ fontWeight: 500 }}>Language Model</span>
+							<span style={{ fontWeight: 500 }}>
+								Language Model <span style={{ color: "#e8912d" }}>*</span>
+							</span>
 						</label>
 						{vsCodeLmModels.length > 0 ? (
 							<VSCodeDropdown
@@ -731,7 +757,9 @@ const ApiOptions = ({
 						style={{ width: "100%" }}
 						onInput={handleInputChange("lmStudioModelId")}
 						placeholder={"e.g. meta-llama-3.1-8b-instruct"}>
-						<span style={{ fontWeight: 500 }}>Model ID</span>
+						<span style={{ fontWeight: 500 }}>
+							Model ID <span style={{ color: "#e8912d" }}>*</span>
+						</span>
 					</VSCodeTextField>
 					{lmStudioModels.length > 0 && (
 						<VSCodeRadioGroup
@@ -793,7 +821,9 @@ const ApiOptions = ({
 						style={{ width: "100%" }}
 						onInput={handleInputChange("liteLlmModelId")}
 						placeholder={"e.g. gpt-4"}>
-						<span style={{ fontWeight: 500 }}>Model ID</span>
+						<span style={{ fontWeight: 500 }}>
+							Model ID <span style={{ color: "#e8912d" }}>*</span>
+						</span>
 					</VSCodeTextField>
 					<p
 						style={{
@@ -825,7 +855,9 @@ const ApiOptions = ({
 						style={{ width: "100%" }}
 						onInput={handleInputChange("ollamaModelId")}
 						placeholder={"e.g. llama3.1"}>
-						<span style={{ fontWeight: 500 }}>Model ID</span>
+						<span style={{ fontWeight: 500 }}>
+							Model ID <span style={{ color: "#e8912d" }}>*</span>
+						</span>
 					</VSCodeTextField>
 					{ollamaModels.length > 0 && (
 						<VSCodeRadioGroup
@@ -876,7 +908,9 @@ const ApiOptions = ({
 					<>
 						<DropdownContainer zIndex={DROPDOWN_Z_INDEX - 2} className="dropdown-container">
 							<label htmlFor="model-id">
-								<span style={{ fontWeight: 500 }}>Model</span>
+								<span style={{ fontWeight: 500 }}>
+									Model <span style={{ color: "#e8912d" }}>*</span>
+								</span>
 							</label>
 							{selectedProvider === "anthropic" && createDropdown(anthropicModels)}
 							{selectedProvider === "bedrock" && createDropdown(bedrockModels)}
@@ -898,28 +932,6 @@ const ApiOptions = ({
 				)}
 
 			{selectedProvider === "openrouter" && showModelOptions && <OpenRouterModelPicker isPopup={isPopup} />}
-
-			{apiErrorMessage && (
-				<p
-					style={{
-						margin: "-10px 0 4px 0",
-						fontSize: 12,
-						color: "var(--vscode-errorForeground)",
-					}}>
-					{apiErrorMessage}
-				</p>
-			)}
-
-			{modelIdErrorMessage && (
-				<p
-					style={{
-						margin: "-10px 0 4px 0",
-						fontSize: 12,
-						color: "var(--vscode-errorForeground)",
-					}}>
-					{modelIdErrorMessage}
-				</p>
-			)}
 
 			{showModelError && isKeyValid !== null && (
 				<Info

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -249,7 +249,7 @@ const ApiOptions = ({ showModelOptions, showModelError = true, isPopup, onValid 
 						onInput={handleInputChange("apiKey")}
 						placeholder="Enter API Key...">
 						<span style={{ fontWeight: 500 }}>
-							Anthropic API Key <span style={{ color: "#e8912d" }}>*</span>
+							Anthropic API Key <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 						</span>
 					</VSCodeTextField>
 
@@ -308,7 +308,7 @@ const ApiOptions = ({ showModelOptions, showModelError = true, isPopup, onValid 
 						onInput={handleInputChange("openAiNativeApiKey")}
 						placeholder="Enter API Key...">
 						<span style={{ fontWeight: 500 }}>
-							OpenAI API Key <span style={{ color: "#e8912d" }}>*</span>
+							OpenAI API Key <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 						</span>
 					</VSCodeTextField>
 					<p
@@ -341,7 +341,7 @@ const ApiOptions = ({ showModelOptions, showModelError = true, isPopup, onValid 
 						onInput={handleInputChange("deepSeekApiKey")}
 						placeholder="Enter API Key...">
 						<span style={{ fontWeight: 500 }}>
-							DeepSeek API Key <span style={{ color: "#e8912d" }}>*</span>
+							DeepSeek API Key <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 						</span>
 					</VSCodeTextField>
 					<p
@@ -374,7 +374,7 @@ const ApiOptions = ({ showModelOptions, showModelError = true, isPopup, onValid 
 						onInput={handleInputChange("mistralApiKey")}
 						placeholder="Enter API Key...">
 						<span style={{ fontWeight: 500 }}>
-							Mistral API Key <span style={{ color: "#e8912d" }}>*</span>
+							Mistral API Key <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 						</span>
 					</VSCodeTextField>
 					<p
@@ -407,7 +407,7 @@ const ApiOptions = ({ showModelOptions, showModelError = true, isPopup, onValid 
 						onInput={handleInputChange("openRouterApiKey")}
 						placeholder="Enter API Key...">
 						<span style={{ fontWeight: 500 }}>
-							OpenRouter API Key <span style={{ color: "#e8912d" }}>*</span>
+							OpenRouter API Key <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 						</span>
 					</VSCodeTextField>
 					{!apiConfiguration?.openRouterApiKey && (
@@ -449,7 +449,7 @@ const ApiOptions = ({ showModelOptions, showModelError = true, isPopup, onValid 
 						onInput={handleInputChange("awsAccessKey")}
 						placeholder="Enter Access Key...">
 						<span style={{ fontWeight: 500 }}>
-							AWS Access Key <span style={{ color: "#e8912d" }}>*</span>
+							AWS Access Key <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 						</span>
 					</VSCodeTextField>
 					<VSCodeTextField
@@ -459,7 +459,7 @@ const ApiOptions = ({ showModelOptions, showModelError = true, isPopup, onValid 
 						onInput={handleInputChange("awsSecretKey")}
 						placeholder="Enter Secret Key...">
 						<span style={{ fontWeight: 500 }}>
-							AWS Secret Key <span style={{ color: "#e8912d" }}>*</span>
+							AWS Secret Key <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 						</span>
 					</VSCodeTextField>
 					<VSCodeTextField
@@ -473,7 +473,7 @@ const ApiOptions = ({ showModelOptions, showModelError = true, isPopup, onValid 
 					<DropdownContainer zIndex={DROPDOWN_Z_INDEX - 1} className="dropdown-container">
 						<label htmlFor="aws-region-dropdown">
 							<span style={{ fontWeight: 500 }}>
-								AWS Region <span style={{ color: "#e8912d" }}>*</span>
+								AWS Region <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 							</span>
 						</label>
 						<VSCodeDropdown
@@ -546,13 +546,13 @@ const ApiOptions = ({ showModelOptions, showModelError = true, isPopup, onValid 
 						onInput={handleInputChange("vertexProjectId")}
 						placeholder="Enter Project ID...">
 						<span style={{ fontWeight: 500 }}>
-							Google Cloud Project ID <span style={{ color: "#e8912d" }}>*</span>
+							Google Cloud Project ID <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 						</span>
 					</VSCodeTextField>
 					<DropdownContainer zIndex={DROPDOWN_Z_INDEX - 2} className="dropdown-container">
 						<label htmlFor="vertex-region-dropdown">
 							<span style={{ fontWeight: 500 }}>
-								Google Cloud Region <span style={{ color: "#e8912d" }}>*</span>
+								Google Cloud Region <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 							</span>
 						</label>
 						<VSCodeDropdown
@@ -598,7 +598,7 @@ const ApiOptions = ({ showModelOptions, showModelError = true, isPopup, onValid 
 						onInput={handleInputChange("geminiApiKey")}
 						placeholder="Enter API Key...">
 						<span style={{ fontWeight: 500 }}>
-							Gemini API Key <span style={{ color: "#e8912d" }}>*</span>
+							Gemini API Key <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 						</span>
 					</VSCodeTextField>
 					<p
@@ -631,7 +631,7 @@ const ApiOptions = ({ showModelOptions, showModelError = true, isPopup, onValid 
 						onInput={handleInputChange("openAiBaseUrl")}
 						placeholder={"Enter base URL..."}>
 						<span style={{ fontWeight: 500 }}>
-							Base URL <span style={{ color: "#e8912d" }}>*</span>
+							Base URL <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 						</span>
 					</VSCodeTextField>
 					<VSCodeTextField
@@ -641,7 +641,7 @@ const ApiOptions = ({ showModelOptions, showModelError = true, isPopup, onValid 
 						onInput={handleInputChange("openAiApiKey")}
 						placeholder="Enter API Key...">
 						<span style={{ fontWeight: 500 }}>
-							API Key <span style={{ color: "#e8912d" }}>*</span>
+							API Key <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 						</span>
 					</VSCodeTextField>
 					<VSCodeTextField
@@ -650,7 +650,7 @@ const ApiOptions = ({ showModelOptions, showModelError = true, isPopup, onValid 
 						onInput={handleInputChange("openAiModelId")}
 						placeholder={"Enter Model ID..."}>
 						<span style={{ fontWeight: 500 }}>
-							Model ID <span style={{ color: "#e8912d" }}>*</span>
+							Model ID <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 						</span>
 					</VSCodeTextField>
 					<VSCodeCheckbox
@@ -683,7 +683,7 @@ const ApiOptions = ({ showModelOptions, showModelError = true, isPopup, onValid 
 					<DropdownContainer zIndex={DROPDOWN_Z_INDEX - 2} className="dropdown-container">
 						<label htmlFor="vscode-lm-model">
 							<span style={{ fontWeight: 500 }}>
-								Language Model <span style={{ color: "#e8912d" }}>*</span>
+								Language Model <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 							</span>
 						</label>
 						{vsCodeLmModels.length > 0 ? (
@@ -758,7 +758,7 @@ const ApiOptions = ({ showModelOptions, showModelError = true, isPopup, onValid 
 						onInput={handleInputChange("lmStudioModelId")}
 						placeholder={"e.g. meta-llama-3.1-8b-instruct"}>
 						<span style={{ fontWeight: 500 }}>
-							Model ID <span style={{ color: "#e8912d" }}>*</span>
+							Model ID <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 						</span>
 					</VSCodeTextField>
 					{lmStudioModels.length > 0 && (
@@ -822,7 +822,7 @@ const ApiOptions = ({ showModelOptions, showModelError = true, isPopup, onValid 
 						onInput={handleInputChange("liteLlmModelId")}
 						placeholder={"e.g. gpt-4"}>
 						<span style={{ fontWeight: 500 }}>
-							Model ID <span style={{ color: "#e8912d" }}>*</span>
+							Model ID <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 						</span>
 					</VSCodeTextField>
 					<p
@@ -856,7 +856,7 @@ const ApiOptions = ({ showModelOptions, showModelError = true, isPopup, onValid 
 						onInput={handleInputChange("ollamaModelId")}
 						placeholder={"e.g. llama3.1"}>
 						<span style={{ fontWeight: 500 }}>
-							Model ID <span style={{ color: "#e8912d" }}>*</span>
+							Model ID <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 						</span>
 					</VSCodeTextField>
 					{ollamaModels.length > 0 && (
@@ -909,7 +909,7 @@ const ApiOptions = ({ showModelOptions, showModelError = true, isPopup, onValid 
 						<DropdownContainer zIndex={DROPDOWN_Z_INDEX - 2} className="dropdown-container">
 							<label htmlFor="model-id">
 								<span style={{ fontWeight: 500 }}>
-									Model <span style={{ color: "#e8912d" }}>*</span>
+									Model <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 								</span>
 							</label>
 							{selectedProvider === "anthropic" && createDropdown(anthropicModels)}

--- a/webview-ui/src/components/settings/EmbeddingOptions.tsx
+++ b/webview-ui/src/components/settings/EmbeddingOptions.tsx
@@ -186,7 +186,7 @@ const EmbeddingOptions = ({ showModelOptions, showModelError = true, onValid }: 
 						onInput={handleInputChange("openAiNativeApiKey")}
 						placeholder="Enter API Key...">
 						<span style={{ fontWeight: 500 }}>
-							OpenAI API Key <span style={{ color: "#e8912d" }}>*</span>
+							OpenAI API Key <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 						</span>
 					</VSCodeTextField>
 					<p
@@ -216,7 +216,7 @@ const EmbeddingOptions = ({ showModelOptions, showModelError = true, onValid }: 
 						onInput={handleInputChange("awsAccessKey")}
 						placeholder="Enter Access Key...">
 						<span style={{ fontWeight: 500 }}>
-							AWS Access Key <span style={{ color: "#e8912d" }}>*</span>
+							AWS Access Key <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 						</span>
 					</VSCodeTextField>
 					<VSCodeTextField
@@ -226,7 +226,7 @@ const EmbeddingOptions = ({ showModelOptions, showModelError = true, onValid }: 
 						onInput={handleInputChange("awsSecretKey")}
 						placeholder="Enter Secret Key...">
 						<span style={{ fontWeight: 500 }}>
-							AWS Secret Key <span style={{ color: "#e8912d" }}>*</span>
+							AWS Secret Key <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 						</span>
 					</VSCodeTextField>
 					<VSCodeTextField
@@ -240,7 +240,7 @@ const EmbeddingOptions = ({ showModelOptions, showModelError = true, onValid }: 
 					<div className="dropdown-container">
 						<label htmlFor="aws-region-dropdown">
 							<span style={{ fontWeight: 500 }}>
-								AWS Region <span style={{ color: "#e8912d" }}>*</span>
+								AWS Region <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 							</span>
 						</label>
 						<VSCodeDropdown
@@ -296,7 +296,7 @@ const EmbeddingOptions = ({ showModelOptions, showModelError = true, onValid }: 
 						onInput={handleInputChange("openAiBaseUrl")}
 						placeholder="Enter base URL...">
 						<span style={{ fontWeight: 500 }}>
-							Base URL <span style={{ color: "#e8912d" }}>*</span>
+							Base URL <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 						</span>
 					</VSCodeTextField>
 					<VSCodeTextField
@@ -306,7 +306,7 @@ const EmbeddingOptions = ({ showModelOptions, showModelError = true, onValid }: 
 						onInput={handleInputChange("openAiApiKey")}
 						placeholder="Enter API Key...">
 						<span style={{ fontWeight: 500 }}>
-							API Key <span style={{ color: "#e8912d" }}>*</span>
+							API Key <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 						</span>
 					</VSCodeTextField>
 					<VSCodeTextField
@@ -316,7 +316,7 @@ const EmbeddingOptions = ({ showModelOptions, showModelError = true, onValid }: 
 						onInput={handleInputChange("openAiModelId")}
 						placeholder="Enter Model ID...">
 						<span style={{ fontWeight: 500 }}>
-							Model ID <span style={{ color: "#e8912d" }}>*</span>
+							Model ID <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 						</span>
 					</VSCodeTextField>
 					<VSCodeCheckbox
@@ -353,7 +353,7 @@ const EmbeddingOptions = ({ showModelOptions, showModelError = true, onValid }: 
 					<div className="dropdown-container">
 						<label htmlFor="ollama-model-id">
 							<span style={{ fontWeight: 500 }}>
-								Model <span style={{ color: "#e8912d" }}>*</span>
+								Model <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 							</span>
 						</label>
 						<VSCodeDropdown
@@ -403,7 +403,7 @@ const EmbeddingOptions = ({ showModelOptions, showModelError = true, onValid }: 
 				<div className="dropdown-container">
 					<label htmlFor="embedding-model">
 						<span style={{ fontWeight: 500 }}>
-							Embedding Model <span style={{ color: "#e8912d" }}>*</span>
+							Embedding Model <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 						</span>
 					</label>
 					<VSCodeDropdown

--- a/webview-ui/src/components/settings/EmbeddingOptions.tsx
+++ b/webview-ui/src/components/settings/EmbeddingOptions.tsx
@@ -21,11 +21,10 @@ interface EmbeddingOptionsProps {
 	showModelOptions: boolean
 	showModelError?: boolean
 	embeddingConfiguration?: EmbeddingConfiguration
-	errorMessage?: string
 	onValid?: (isValid: boolean) => void
 }
 
-const EmbeddingOptions = ({ showModelOptions, showModelError = true, errorMessage, onValid }: EmbeddingOptionsProps) => {
+const EmbeddingOptions = ({ showModelOptions, showModelError = true, onValid }: EmbeddingOptionsProps) => {
 	const { embeddingConfiguration, setEmbeddingConfiguration, apiConfiguration, setBuildContextOptions, buildContextOptions } =
 		useExtensionState()
 	const [azureOpenAIApiVersionSelected, setAzureOpenAIApiVersionSelected] = useState(
@@ -78,10 +77,12 @@ const EmbeddingOptions = ({ showModelOptions, showModelError = true, errorMessag
 
 	useDeepCompareEffect(() => {
 		const error = validateEmbeddingConfiguration(embeddingConfiguration)
-		if (!error) {
-			setValidateEmbedding(embeddingConfiguration)
-		} else {
+
+		if (error) {
 			setIsEmbeddingValid(null)
+			vscode.postMessage({ type: "validateEmbeddingConfig", embeddingConfiguration, text: error })
+		} else {
+			setValidateEmbedding(embeddingConfiguration)
 		}
 	}, [embeddingConfiguration])
 
@@ -184,7 +185,9 @@ const EmbeddingOptions = ({ showModelOptions, showModelError = true, errorMessag
 						type="password"
 						onInput={handleInputChange("openAiNativeApiKey")}
 						placeholder="Enter API Key...">
-						<span style={{ fontWeight: 500 }}>OpenAI API Key</span>
+						<span style={{ fontWeight: 500 }}>
+							OpenAI API Key <span style={{ color: "#e8912d" }}>*</span>
+						</span>
 					</VSCodeTextField>
 					<p
 						style={{
@@ -212,7 +215,9 @@ const EmbeddingOptions = ({ showModelOptions, showModelError = true, errorMessag
 						type="password"
 						onInput={handleInputChange("awsAccessKey")}
 						placeholder="Enter Access Key...">
-						<span style={{ fontWeight: 500 }}>AWS Access Key</span>
+						<span style={{ fontWeight: 500 }}>
+							AWS Access Key <span style={{ color: "#e8912d" }}>*</span>
+						</span>
 					</VSCodeTextField>
 					<VSCodeTextField
 						value={embeddingConfiguration?.awsSecretKey || ""}
@@ -220,7 +225,9 @@ const EmbeddingOptions = ({ showModelOptions, showModelError = true, errorMessag
 						type="password"
 						onInput={handleInputChange("awsSecretKey")}
 						placeholder="Enter Secret Key...">
-						<span style={{ fontWeight: 500 }}>AWS Secret Key</span>
+						<span style={{ fontWeight: 500 }}>
+							AWS Secret Key <span style={{ color: "#e8912d" }}>*</span>
+						</span>
 					</VSCodeTextField>
 					<VSCodeTextField
 						value={embeddingConfiguration?.awsSessionToken || ""}
@@ -232,7 +239,9 @@ const EmbeddingOptions = ({ showModelOptions, showModelError = true, errorMessag
 					</VSCodeTextField>
 					<div className="dropdown-container">
 						<label htmlFor="aws-region-dropdown">
-							<span style={{ fontWeight: 500 }}>AWS Region</span>
+							<span style={{ fontWeight: 500 }}>
+								AWS Region <span style={{ color: "#e8912d" }}>*</span>
+							</span>
 						</label>
 						<VSCodeDropdown
 							id="aws-region-dropdown"
@@ -286,7 +295,9 @@ const EmbeddingOptions = ({ showModelOptions, showModelError = true, errorMessag
 						type="text"
 						onInput={handleInputChange("openAiBaseUrl")}
 						placeholder="Enter base URL...">
-						<span style={{ fontWeight: 500 }}>Base URL</span>
+						<span style={{ fontWeight: 500 }}>
+							Base URL <span style={{ color: "#e8912d" }}>*</span>
+						</span>
 					</VSCodeTextField>
 					<VSCodeTextField
 						value={embeddingConfiguration?.openAiApiKey || ""}
@@ -294,7 +305,9 @@ const EmbeddingOptions = ({ showModelOptions, showModelError = true, errorMessag
 						type="password"
 						onInput={handleInputChange("openAiApiKey")}
 						placeholder="Enter API Key...">
-						<span style={{ fontWeight: 500 }}>API Key</span>
+						<span style={{ fontWeight: 500 }}>
+							API Key <span style={{ color: "#e8912d" }}>*</span>
+						</span>
 					</VSCodeTextField>
 					<VSCodeTextField
 						value={embeddingConfiguration?.openAiModelId || ""}
@@ -302,7 +315,9 @@ const EmbeddingOptions = ({ showModelOptions, showModelError = true, errorMessag
 						type="text"
 						onInput={handleInputChange("openAiModelId")}
 						placeholder="Enter Model ID...">
-						<span style={{ fontWeight: 500 }}>Model ID</span>
+						<span style={{ fontWeight: 500 }}>
+							Model ID <span style={{ color: "#e8912d" }}>*</span>
+						</span>
 					</VSCodeTextField>
 					<VSCodeCheckbox
 						checked={azureOpenAIApiVersionSelected}
@@ -337,7 +352,9 @@ const EmbeddingOptions = ({ showModelOptions, showModelError = true, errorMessag
 					</VSCodeTextField>
 					<div className="dropdown-container">
 						<label htmlFor="ollama-model-id">
-							<span style={{ fontWeight: 500 }}>Model</span>
+							<span style={{ fontWeight: 500 }}>
+								Model <span style={{ color: "#e8912d" }}>*</span>
+							</span>
 						</label>
 						<VSCodeDropdown
 							id="ollama-model-id"
@@ -385,7 +402,9 @@ const EmbeddingOptions = ({ showModelOptions, showModelError = true, errorMessag
 			{selectedProvider && Object.keys(availableModels).length > 0 && (
 				<div className="dropdown-container">
 					<label htmlFor="embedding-model">
-						<span style={{ fontWeight: 500 }}>Embedding Model</span>
+						<span style={{ fontWeight: 500 }}>
+							Embedding Model <span style={{ color: "#e8912d" }}>*</span>
+						</span>
 					</label>
 					<VSCodeDropdown
 						id="embedding-model"
@@ -443,17 +462,6 @@ const EmbeddingOptions = ({ showModelOptions, showModelError = true, errorMessag
 				}}>
 				Same as LLM API configuration
 			</VSCodeCheckbox>
-
-			{errorMessage && (
-				<p
-					style={{
-						margin: "5px 0",
-						fontSize: 12,
-						color: "var(--vscode-errorForeground)",
-					}}>
-					{errorMessage}
-				</p>
-			)}
 
 			{showModelError && isEmbeddingValid !== null && (
 				<Info

--- a/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
+++ b/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
@@ -147,7 +147,9 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup }
 			</style>
 			<div style={{ display: "flex", flexDirection: "column" }}>
 				<label htmlFor="model-search">
-					<span style={{ fontWeight: 500 }}>Model</span>
+					<span style={{ fontWeight: 500 }}>
+						Model <span style={{ color: "#e8912d" }}>*</span>
+					</span>
 				</label>
 				<DropdownWrapper ref={dropdownRef}>
 					<VSCodeTextField

--- a/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
+++ b/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
@@ -148,7 +148,7 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup }
 			<div style={{ display: "flex", flexDirection: "column" }}>
 				<label htmlFor="model-search">
 					<span style={{ fontWeight: 500 }}>
-						Model <span style={{ color: "#e8912d" }}>*</span>
+						Model <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>
 					</span>
 				</label>
 				<DropdownWrapper ref={dropdownRef}>

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -132,10 +132,7 @@ const SettingsView = () => {
 
 	useDebounce(
 		() => {
-			const defaultInstruction = (customInstructions || "").trim()
-			if (defaultInstruction) {
-				vscode.postMessage({ type: "customInstructions", text: defaultInstruction })
-			}
+			vscode.postMessage({ type: "customInstructions", text: customInstructions || "" })
 		},
 		500,
 		[customInstructions],

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -1,7 +1,6 @@
 import { VSCodeButton, VSCodeLink, VSCodeTextArea } from "@vscode/webview-ui-toolkit/react"
-import { memo, useEffect, useState } from "react"
+import { memo, useState } from "react"
 import { useExtensionState } from "../../context/ExtensionStateContext"
-import { validateApiConfiguration, validateEmbeddingConfiguration, validateModelId } from "../../utils/validate"
 import { vscode } from "../../utils/vscode"
 import ApiOptions from "./ApiOptions"
 import SettingsViewExtra from "./SettingsViewExtra"
@@ -9,14 +8,11 @@ import EmbeddingOptions from "./EmbeddingOptions"
 import { ACCEPTED_FILE_EXTENSIONS } from "../../utils/constants"
 import { HaiInstructionFile } from "../../../../src/shared/customApi"
 import SettingsButton from "../common/SettingsButton"
+import { useDebounce, useDeepCompareEffect } from "react-use"
 
 const IS_DEV = true // FIXME: use flags when packaging
 
-type SettingsViewProps = {
-	onDone: () => void
-}
-
-const SettingsView = ({ onDone }: SettingsViewProps) => {
+const SettingsView = () => {
 	const {
 		apiConfiguration,
 		version,
@@ -31,9 +27,6 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 		setFileInstructions,
 		vscodeWorkspacePath,
 	} = useExtensionState()
-	const [apiErrorMessage, setApiErrorMessage] = useState<string | undefined>(undefined)
-	const [modelIdErrorMessage, setModelIdErrorMessage] = useState<string | undefined>(undefined)
-	const [embeddingErrorMessage, setEmbeddingErrorMessage] = useState<string | undefined>(undefined)
 	const [showCopied, setShowCopied] = useState(false)
 	const [trashClickedFiles, setTrashClickedFiles] = useState<Set<string>>(new Set())
 
@@ -47,29 +40,6 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 			}
 			return newSet
 		})
-	}
-
-	useEffect(() => {
-		setApiErrorMessage(undefined)
-		setModelIdErrorMessage(undefined)
-		setEmbeddingErrorMessage(undefined)
-	}, [apiConfiguration, embeddingConfiguration])
-
-	const handleSubmit = () => {
-		const apiValidationResult = validateApiConfiguration(apiConfiguration)
-		const modelIdValidationResult = validateModelId(apiConfiguration, openRouterModels)
-		const embeddingValidationResult = validateEmbeddingConfiguration(embeddingConfiguration)
-
-		setApiErrorMessage(apiValidationResult)
-		setEmbeddingErrorMessage(embeddingValidationResult)
-
-		if (!apiValidationResult && !modelIdValidationResult) {
-			vscode.postMessage({ type: "apiConfiguration", apiConfiguration })
-			vscode.postMessage({ type: "customInstructions", text: customInstructions })
-			vscode.postMessage({ type: "buildContextOptions", buildContextOptions: buildContextOptions })
-			vscode.postMessage({ type: "embeddingConfiguration", embeddingConfiguration })
-			onDone()
-		}
 	}
 
 	const [fileInput, setFileInput] = useState<HaiInstructionFile[]>([])
@@ -160,6 +130,21 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 		setTimeout(() => setShowCopied(false), 2000)
 	}
 
+	useDebounce(
+		() => {
+			const defaultInstruction = (customInstructions || "").trim()
+			if (defaultInstruction) {
+				vscode.postMessage({ type: "customInstructions", text: defaultInstruction })
+			}
+		},
+		500,
+		[customInstructions],
+	)
+
+	useDeepCompareEffect(() => {
+		vscode.postMessage({ type: "buildContextOptions", buildContextOptions: buildContextOptions })
+	}, [buildContextOptions])
+
 	return (
 		<div
 			style={{
@@ -182,7 +167,6 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 					paddingRight: 17,
 				}}>
 				<h3 style={{ color: "var(--vscode-foreground)", margin: 0 }}>Settings</h3>
-				<VSCodeButton onClick={handleSubmit}>Done</VSCodeButton>
 			</div>
 			<div
 				style={{
@@ -194,16 +178,12 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 				}}>
 				<div style={{ marginBottom: 10 }}>
 					<h3 style={{ marginBottom: 5 }}>LLM API Configuration</h3>
-					<ApiOptions
-						showModelOptions={true}
-						apiErrorMessage={apiErrorMessage}
-						modelIdErrorMessage={modelIdErrorMessage}
-					/>
+					<ApiOptions showModelOptions={true} />
 				</div>
 
 				<div style={{ marginBottom: 10 }}>
 					<h3 style={{ marginBottom: 5 }}>Embedding Configuration</h3>
-					<EmbeddingOptions showModelOptions={true} errorMessage={embeddingErrorMessage} />
+					<EmbeddingOptions showModelOptions={true} />
 				</div>
 
 				<div style={{ marginBottom: 5 }}>


### PR DESCRIPTION
### Description

This feature introduces autosave for all settings.

- The previous validation, which was triggered only when clicking the Done button, has been replaced with an asterisk (*) to indicate required fields.
- The remaining validation sequence remains unchanged.
- **In the previous version:**
if a required field was cleared and the user navigated away without clicking Done, the change wouldn’t be saved. However, if Done was clicked, a required field error would be displayed.

  **In the current version:**
  Clearing a required field will remove its value from both the workspace and global state, and the change will be automatically saved.

Gist on file-wise changes: 

- ClineProvider: Refactored LLM and Embedding state updates into a reusable function and added required field validation to prevent unnecessary LLM calls.
- App.tsx & SettingsView.tsx: Removed `onDone` and `handleSubmit` as they are no longer needed.
- ChatTextArea.tsx & ApiOptions.tsx: Moved `apiError` and `modelIdError` handling to ApiOption, added `modelId` validation, and marked required fields with an asterisk (*).
- EmbeddingOptions.tsx: Added an asterisk (*) for required fields and removed error message rendering.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="428" alt="Screenshot 2025-02-18 at 9 31 14 AM" src="https://github.com/user-attachments/assets/43879b10-b32f-435d-b613-3a1eeebd6ce9" />

