### PR TITLE
Add code indexing notification with user controls and a privacy warning

### DIFF
--- a/.changeset/lazy-lies-smash.md
+++ b/.changeset/lazy-lies-smash.md
@@ -1,0 +1,5 @@
+---
+"hai-build-code-generator": patch
+---
+
+Updated code indexing notification with user controls and a privacy warning

--- a/webview-ui/src/components/settings/SettingsViewExtra.tsx
+++ b/webview-ui/src/components/settings/SettingsViewExtra.tsx
@@ -149,6 +149,18 @@ const SettingsViewExtra = ({
 					When enabled, HAI will automatically index your code. This is useful for finding relevant files for the tasks
 					you are working on.
 				</p>
+				<p
+					style={{
+						fontSize: "12px",
+						marginTop: "5px",
+						color: "var(--vscode-descriptionForeground)",
+					}}>
+					<span style={{ color: "var(--vscode-errorForeground)" }}>
+						(<span style={{ fontWeight: 500 }}>Note:</span> Code indexing will read all your file content and send it
+						to the LLM to generate embeddings. If not excluded, sensitive or private data may be included in this
+						process. Use this feature at your own risk.)
+					</span>
+				</p>
 			</div>
 
 			<div style={{ marginBottom: 5 }}>

--- a/webview-ui/src/components/settings/SettingsViewExtra.tsx
+++ b/webview-ui/src/components/settings/SettingsViewExtra.tsx
@@ -156,9 +156,8 @@ const SettingsViewExtra = ({
 						color: "var(--vscode-descriptionForeground)",
 					}}>
 					<span style={{ color: "var(--vscode-errorForeground)" }}>
-						(<span style={{ fontWeight: 500 }}>Note:</span> Code indexing will read all your file content and send it
-						to the LLM to generate embeddings. If not excluded, sensitive or private data may be included in this
-						process. Use this feature at your own risk.)
+						(<span style={{ fontWeight: 500 }}>Note:</span> Code indexing reads all file content and sends it to the
+						LLM to generate embeddings. Exclude sensitive data to prevent unintended inclusion.)
 					</span>
 				</p>
 			</div>


### PR DESCRIPTION
### Description

- The Code Index notification appears when code indexing is enabled (default: Yes) and the progress is at 0% (i.e., indexing has not started yet).
- The notification provides three options:
  * Open Settings: Navigates the user to the settings screen.
  * No: Disables code indexing, preventing future notifications.
  * Cancel: Closes the notification without making any changes.
- Once code indexing has started or completed, the notification will no longer appear.
- A warning note has been added to inform users about the data usage of code indexing.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)

### Screenshots

![image](https://github.com/user-attachments/assets/76d8f182-9a4e-4119-8606-ebb49f162bcf)
![image](https://github.com/user-attachments/assets/de214847-6df0-4924-9a25-8c7cb825333c)
