### PR TITLE
feat: add inline editing configuration option for hai

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,6 +187,11 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Enables extension to save checkpoints of workspace throughout the task."
+				},
+				"hai.inlineEditing": {
+					"type": "boolean",
+					"default": true,
+					"description": "Enables inline editing with HAI"
 				}
 			}
 		}

--- a/src/integrations/inline-editing/index.ts
+++ b/src/integrations/inline-editing/index.ts
@@ -339,10 +339,18 @@ export class InlineEditingProvider {
 	registerCodeLensProvider() {
 		this.activeCodeLensProvider?.dispose()
 		const isEditing = this.isEditing
+		const isInlineEditEnabled = vscode.workspace.getConfiguration("hai").get<boolean>("inlineEditing") ?? true
 		const provider = vscode.languages.registerCodeLensProvider("*", {
 			provideCodeLenses(document) {
 				const editor = vscode.window.activeTextEditor
-				if (editor && editor.document === document && editor.selection && !isEditing && !editor.selection.isEmpty) {
+				if (
+					editor &&
+					editor.document === document &&
+					editor.selection &&
+					!isEditing &&
+					!editor.selection.isEmpty &&
+					isInlineEditEnabled
+				) {
 					return [
 						new vscode.CodeLens(editor.selection, {
 							title: "⌥⇧K Edit with hAI",


### PR DESCRIPTION
### Description
- Toggle Inline Editing Option for HAI from Advanced Settings (Redirects to VS Code Settings of HAI)

### Type of Change
-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist
-   [] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)

### Screenshots
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/43241795-fe7b-44ae-ad6c-ac055cf6df4e" />

### Additional Notes
Linked Issue: https://github.com/presidio-oss/cline-based-code-generator/issues/69
