### PR TITLE
fix: fixed issue in github artifact pushed to teams

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -77,7 +77,10 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NOTIFICATION_URL: ${{ secrets.NOTIFICATION_URL }}
               run: |
-                  ARTIFACT_ID=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts --header "authorization: Bearer $GITHUB_TOKEN" | jq -r '.artifacts[0].id')
+                  ARTIFACT_NAME="${{ env.PACKAGE_NAME }}-${{ env.BUILD_VERSION }}"
+                  echo "Artifact name: $ARTIFACT_NAME"
+
+                  ARTIFACT_ID=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts --header "authorization: Bearer $GITHUB_TOKEN" | jq -r --arg NAME "$ARTIFACT_NAME" '.artifacts[] | select(.name == $NAME) | .id')
 
                   if [[ -z "$ARTIFACT_ID" || "$ARTIFACT_ID" == "null" ]]; then
                     echo "❌ ERROR: ARTIFACT_ID is missing or invalid."


### PR DESCRIPTION
### Description

The issue was that the coverage report artifact was uploaded instead of the VSIX package.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)
