### PR TITLE
fix: removed embedding from plan/act toggle card in settings

### DIFF
--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -141,7 +141,7 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 							border: "1px solid var(--vscode-panel-border)",
 							borderRadius: "4px",
 							padding: "10px",
-							marginBottom: "20px",
+							marginBottom: "10px",
 							background: "var(--vscode-panel-background)",
 						}}>
 						<div
@@ -166,26 +166,19 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 								<h3 style={{ marginBottom: 5 }}>LLM API Configuration</h3>
 								<ApiOptions key={chatSettings.mode} showModelOptions={true} />
 							</div>
-
-							<div style={{ marginBottom: 10 }}>
-								<h3 style={{ marginBottom: 5 }}>Embedding Configuration</h3>
-								<EmbeddingOptions key={chatSettings.mode} showModelOptions={true} />
-							</div>
 						</div>
 					</div>
 				) : (
-					<>
-						<div style={{ marginBottom: 10 }}>
-							<h3 style={{ marginBottom: 5 }}>LLM API Configuration</h3>
-							<ApiOptions key={"single"} showModelOptions={true} />
-						</div>
-
-						<div style={{ marginBottom: 10 }}>
-							<h3 style={{ marginBottom: 5 }}>Embedding Configuration</h3>
-							<EmbeddingOptions key={"single"} showModelOptions={true} />
-						</div>
-					</>
+					<div style={{ marginBottom: 10 }}>
+						<h3 style={{ marginBottom: 5 }}>LLM API Configuration</h3>
+						<ApiOptions key={"single"} showModelOptions={true} />
+					</div>
 				)}
+
+				<div style={{ marginBottom: 10 }}>
+					<h3 style={{ marginBottom: 5 }}>Embedding Configuration</h3>
+					<EmbeddingOptions showModelOptions={true} />
+				</div>
 
 				<div style={{ marginBottom: 5 }}>
 					<VSCodeTextArea


### PR DESCRIPTION
### Description

Removed embedding configuration from the plan/act toggle card since we won't have different models used for embeddings based on the mode

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="380" alt="image" src="https://github.com/user-attachments/assets/5d4f461a-e6a0-489c-97fb-fe66c700dd76" />
