### PR TITLE
fix: fixed find-files-agent returned empty files even after indexing

### DIFF
--- a/.changeset/bright-dots-appear.md
+++ b/.changeset/bright-dots-appear.md
@@ -1,0 +1,5 @@
+---
+"hai-build-code-generator": patch
+---
+
+Fixed find-files-agent returned empty files even after indexing

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -176,6 +176,7 @@ export class Task {
 		this.chatSettings = chatSettings
 
 		// HAI variable initialization
+		this.task = task
 		this.expertPrompt = expertPrompt
 		this.apiConfiguration = apiConfiguration
 		this.embeddingConfiguration = embeddingConfiguration


### PR DESCRIPTION
### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)

### Screenshots

![image](https://github.com/user-attachments/assets/b5612d4b-3b1e-4e2b-8f78-3f4ed32523aa)

