### PR TITLE
fix: v3 and prompt caching been set as default and fixed the issue in esbuild

### DIFF
--- a/.changeset/strange-ducks-deny.md
+++ b/.changeset/strange-ducks-deny.md
@@ -1,0 +1,7 @@
+---
+"hai-build-code-generator": patch
+---
+
+- Enabled prompt caching by default for bedrock
+- Set V3 prompt as default in the settings
+- Fixed issue in esbuild

--- a/esbuild.js
+++ b/esbuild.js
@@ -95,7 +95,7 @@ const extensionConfig = {
 	outfile: "dist/extension.js",
 	external: ["vscode", "faiss-node"],
 	define: {
-		"process.env.POST_HOG_API_KEY": JSON.stringify(process.env.POST_HOG_API_KEY || ""),
+		"process.env.POST_HOG_API_KEY": JSON.stringify(process.env.POST_HOG_API_KEY || "api-key"),
 		"process.env.POST_HOG_HOST": JSON.stringify(process.env.POST_HOG_HOST || "https://us.i.posthog.com"),
 		"process.env.LANGFUSE_API_KEY": JSON.stringify(process.env.LANGFUSE_API_KEY || ""),
 		"process.env.LANGFUSE_PUBLIC_KEY": JSON.stringify(process.env.LANGFUSE_PUBLIC_KEY || ""),

--- a/src/core/storage/state.ts
+++ b/src/core/storage/state.ts
@@ -427,12 +427,18 @@ export async function getAllExtensionState(context: vscode.ExtensionContext, wor
 		expertPrompt,
 		isHaiRulesPresent,
 		taskHistory,
-		buildContextOptions: buildContextOptions ?? {
-			useIndex: true, // Enable Indexing by default
-			useContext: true, // Enable Use Context by default
-			useSyncWithApi: true, // Enable Sync with API by default
-			useSecretScanning: true, // Enable Secret Scanning by default
-		},
+		buildContextOptions: buildContextOptions
+			? {
+					...buildContextOptions,
+					systemPromptVersion: buildContextOptions.systemPromptVersion ?? "v3",
+				}
+			: {
+					useIndex: true, // Enable Indexing by default
+					useContext: true, // Enable Use Context by default
+					useSyncWithApi: true, // Enable Sync with API by default
+					useSecretScanning: true, // Enable Secret Scanning by default
+					systemPromptVersion: "v3", // Setting v3 as default prompt
+				},
 		buildIndexProgress: buildIndexProgress,
 		autoApprovalSettings: autoApprovalSettings || DEFAULT_AUTO_APPROVAL_SETTINGS, // default value can be 0 or empty string
 		browserSettings: browserSettings || DEFAULT_BROWSER_SETTINGS,

--- a/src/core/storage/state.ts
+++ b/src/core/storage/state.ts
@@ -361,7 +361,7 @@ export async function getAllExtensionState(context: vscode.ExtensionContext, wor
 			awsSessionToken,
 			awsRegion,
 			awsUseCrossRegionInference,
-			awsBedrockUsePromptCache,
+			awsBedrockUsePromptCache: awsBedrockUsePromptCache ?? true,
 			awsBedrockEndpoint,
 			awsProfile,
 			awsUseProfile,

--- a/webview-ui/src/components/common/TelemetryBanner.tsx
+++ b/webview-ui/src/components/common/TelemetryBanner.tsx
@@ -51,7 +51,7 @@ const TelemetryBanner = () => {
 					<a href="https://docs.github.com/en/get-started/git-basics/setting-your-username-in-git">
 						git username and email
 					</a>{" "}
-					are sent to help us identify the user.
+					are sent for analytics.
 					<div style={{ marginTop: 4 }}>
 						You can always change this in{" "}
 						<VSCodeLink href="#" onClick={handleOpenSettings}>

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -688,7 +688,7 @@ const ApiOptions = ({ showModelOptions, showModelError = true, isPopup, onValid 
 						{selectedModelInfo.supportsPromptCache && (
 							<>
 								<VSCodeCheckbox
-									checked={apiConfiguration?.awsBedrockUsePromptCache || false}
+									checked={apiConfiguration?.awsBedrockUsePromptCache ?? true}
 									onChange={(e: any) => {
 										const isChecked = e.target.checked === true
 										setApiConfiguration({

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -267,7 +267,7 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 						<a href="https://docs.github.com/en/get-started/git-basics/setting-your-username-in-git">
 							git username and email
 						</a>{" "}
-						are sent to help us identify the user.
+						are sent for analytics.
 					</p>
 				</div>
 

--- a/webview-ui/src/components/settings/SettingsViewExtra.tsx
+++ b/webview-ui/src/components/settings/SettingsViewExtra.tsx
@@ -152,7 +152,7 @@ const SettingsViewExtra = ({
 					</label>
 					<VSCodeDropdown
 						id="system-prompt-version"
-						value={buildContextOptions?.systemPromptVersion || "default"}
+						value={buildContextOptions?.systemPromptVersion || "v3"}
 						onChange={(event: any) => {
 							setBuildContextOptions({
 								...buildContextOptions!,


### PR DESCRIPTION
### Description

Fixed and added the following:
- Fixed issue in esbuild (Added a dummy api-key)
- Enabled prompt caching for Bedrock
- Set v3 as default prompt in settings
- Analytics info update

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)
