### PR TITLE
feat: implement feature to mark tasks as 'Completed' after successful execution

### DIFF
--- a/.changeset/lovely-avocados-do.md
+++ b/.changeset/lovely-avocados-do.md
@@ -1,0 +1,5 @@
+---
+"hai-build-code-generator": minor
+---
+
+Marking the Hai tasks as 'Completed' upon successful execution

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -943,6 +943,44 @@ export class Controller {
 					break
 				}
 				break
+			case "writeTaskStatus":
+				// write status to the file
+				const folder = message.folder
+				const taskId = message?.taskId ?? ""
+				const status = message?.status
+				const taskIdMatch = taskId.match(/^(\d+)-US(\d+)-TASK(\d+)$/)
+				if (!folder || !taskIdMatch || !status) {
+					const message = `Failed to update task status. Error: Either folder, taskId or status is invalid.`
+					vscode.window.showErrorMessage(message)
+				} else {
+					const [_, prdId, usId, taskId] = taskIdMatch
+					const prdFeatureFilePath = path.join(`${folder}`, "PRD", `PRD${prdId}-feature.json`)
+					try {
+						const fileContent = await fs.readFile(prdFeatureFilePath, "utf-8")
+						const prdFeatureJson = JSON.parse(fileContent)
+						const feature = prdFeatureJson["features"].find((feature: { id: string }) => feature.id === `US${usId}`)
+						if (feature) {
+							const selectedTask = feature["tasks"].find((task: { id: string }) => task.id === `TASK${taskId}`)
+							selectedTask.status = status
+						}
+
+						await fs.writeFile(prdFeatureFilePath, JSON.stringify(prdFeatureJson, null, 2), "utf-8")
+						const message = `Successfully marked task as ${status.toLowerCase()}.`
+						vscode.window.showInformationMessage(message)
+						await this.postMessageToWebview({
+							type: "writeTaskStatus",
+							writeTaskStatusResult: {
+								success: true,
+								message,
+								status,
+							},
+						})
+					} catch (error) {
+						const message = `Failed to mark task as ${status.toLowerCase()}. Error: ${error.message}`
+						vscode.window.showErrorMessage(message)
+					}
+				}
+				break
 			default:
 				this.customWebViewMessageHandlers(message)
 				break
@@ -2438,7 +2476,13 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 				.filter((file: string) => file.match(/\-feature.json$/))
 				.forEach((file: string) => {
 					const content = fs.readFileSync(path.join(`${url}/PRD`, file), "utf-8")
-					haiTaskList = [...haiTaskList, ...JSON.parse(content).features]
+					const prdId = file.split("-")[0].replace("PRD", "")
+					const parsedFeaturesList = JSON.parse(content).features
+					const featuresListWithPrdId = parsedFeaturesList.map((feature: any) => ({
+						...feature,
+						prdId: prdId,
+					}))
+					haiTaskList = [...haiTaskList, ...featuresListWithPrdId]
 				})
 			return haiTaskList
 		} catch (e) {

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -52,6 +52,7 @@ export interface ExtensionMessage {
 		| "addToInput"
 		| "expertsUpdated"
 		| "expertPrompt"
+		| "writeTaskStatus"
 	text?: string
 	bool?: boolean
 	action?:
@@ -104,6 +105,11 @@ export interface ExtensionMessage {
 		success: boolean
 		serverName: string
 		error?: string
+	}
+	writeTaskStatusResult?: {
+		success: boolean
+		message: string
+		status: string
 	}
 }
 

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -88,6 +88,7 @@ export interface WebviewMessage {
 		| "optionsResponse"
 		| "requestTotalTasksSize"
 		| "taskFeedback"
+		| "writeTaskStatus"
 	// | "relaunchChromeDebugMode"
 	text?: string
 	disabled?: boolean
@@ -105,6 +106,9 @@ export interface WebviewMessage {
 	isDefault?: boolean
 	prompt?: string
 	category?: string
+	folder?: string
+	taskId?: string
+	status?: string
 
 	buildContextOptions?: HaiBuildContextOptions
 	embeddingConfiguration?: EmbeddingConfiguration

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -241,6 +241,7 @@ const AppContent = () => {
 								hideAnnouncement={() => {
 									setShowAnnouncement(false)
 								}}
+								haiConfig={haiConfig}
 							/>
 						</>
 					)}

--- a/webview-ui/src/components/hai/HaiStoryAccordion.tsx
+++ b/webview-ui/src/components/hai/HaiStoryAccordion.tsx
@@ -11,6 +11,7 @@ interface HaiStoryAccordionProps {
 	tasks: IHaiTask[]
 	onTaskSelect: (task: IHaiClineTask) => void
 	id: string
+	prdId: string
 	storyTicketId?: string
 	isAllExpanded: boolean
 }
@@ -24,6 +25,7 @@ export const HaiStoryAccordion: React.FC<HaiStoryAccordionProps> = ({
 	description,
 	storyTicketId,
 	id,
+	prdId,
 	isAllExpanded,
 }) => {
 	const [isExpanded, setIsExpanded] = useState<boolean>(true)
@@ -136,7 +138,7 @@ export const HaiStoryAccordion: React.FC<HaiStoryAccordionProps> = ({
 					<VSCodeButton
 						appearance="icon"
 						title="View Story"
-						onClick={() => onStoryClick({ id, name, description, storyTicketId, tasks })}>
+						onClick={() => onStoryClick({ id, prdId, name, description, storyTicketId, tasks })}>
 						<span
 							className="codicon codicon-eye"
 							style={{
@@ -169,6 +171,7 @@ export const HaiStoryAccordion: React.FC<HaiStoryAccordionProps> = ({
 											name={name}
 											description={description}
 											task={task}
+											prdId={prdId}
 											onTaskSelect={onTaskSelect}
 											onTaskClick={onTaskClick}
 										/>

--- a/webview-ui/src/components/hai/HaiTaskComponent.tsx
+++ b/webview-ui/src/components/hai/HaiTaskComponent.tsx
@@ -5,6 +5,7 @@ import CopyClipboard from "../common/CopyClipboard"
 
 interface HaiTaskComponentProps {
 	id: string
+	prdId: string
 	name: string
 	description: string
 	task: IHaiTask
@@ -12,7 +13,7 @@ interface HaiTaskComponentProps {
 	onTaskSelect: (task: IHaiClineTask) => void
 }
 
-const HaiTaskComponent: React.FC<HaiTaskComponentProps> = ({ id, name, description, task, onTaskSelect, onTaskClick }) => {
+const HaiTaskComponent: React.FC<HaiTaskComponentProps> = ({ id, prdId, name, description, task, onTaskSelect, onTaskClick }) => {
 	return (
 		<div
 			style={{
@@ -43,6 +44,7 @@ const HaiTaskComponent: React.FC<HaiTaskComponentProps> = ({ id, name, descripti
 						textOverflow: "ellipsis",
 						display: "flex",
 						flexDirection: "row",
+						alignItems: "center",
 					}}>
 					<span
 						style={{
@@ -65,6 +67,12 @@ const HaiTaskComponent: React.FC<HaiTaskComponentProps> = ({ id, name, descripti
 							/>
 						)}{" "}
 					</span>
+					{task.status === "Completed" && (
+						<span
+							className={`codicon codicon-pass-filled`}
+							style={{ marginLeft: "4px", color: "green", fontSize: "13px" }}
+						/>
+					)}
 				</div>
 				<span
 					style={{
@@ -92,7 +100,7 @@ const HaiTaskComponent: React.FC<HaiTaskComponentProps> = ({ id, name, descripti
 						onTaskSelect({
 							context: `${name}: ${description}`,
 							...task,
-							id: `${id}-${task.id}`,
+							id: `${prdId}-${id}-${task.id}`,
 						})
 					}}>
 					<span className="codicon codicon-play" style={{ fontSize: 14, cursor: "pointer" }} />

--- a/webview-ui/src/components/hai/hai-tasks-list.tsx
+++ b/webview-ui/src/components/hai/hai-tasks-list.tsx
@@ -210,6 +210,7 @@ export function HaiTasksList({
 								name={story.name}
 								tasks={story.tasks}
 								id={story.id}
+								prdId={story.prdId}
 								onTaskSelect={selectedHaiTask}
 								onTaskClick={onTaskClick}
 								onStoryClick={onStoryClick}

--- a/webview-ui/src/components/welcome/QuickActions.tsx
+++ b/webview-ui/src/components/welcome/QuickActions.tsx
@@ -13,6 +13,7 @@ const createHaiTask = (title: string, description: string, context: string): IHa
 	list: title,
 	acceptance: description,
 	id: "",
+	status: "",
 })
 
 const QuickActions = ({ onTaskSelect }: QuickActionProps) => {

--- a/webview-ui/src/interfaces/hai-task.interface.ts
+++ b/webview-ui/src/interfaces/hai-task.interface.ts
@@ -3,6 +3,7 @@ export interface IHaiTask {
 	acceptance: string
 	id: string
 	subTaskTicketId?: string
+	status: string
 }
 
 export interface IHaiClineTask extends IHaiTask {
@@ -11,6 +12,7 @@ export interface IHaiClineTask extends IHaiTask {
 
 export interface IHaiStory {
 	id: string
+	prdId: string
 	name: string
 	description: string
 	storyTicketId?: string


### PR DESCRIPTION
## Description

#### Marking Task as `Completed`
- When user selected Hai task successfully executes, the chat window prompts the user with confirmation message asking whether they wish to mark the task as `Completed`. Two buttons are presented beneath the confirmation prompt to accept or to decline the prompt.
- If the user confirms the prompt, a new field named `status` with the value `Completed` is added to the task object in the corresponding PRD feature JSON file.
- If the user declines, no changes are made to the PRD feature files, and the confirmation prompt is simply hidden.
- If the user is not satisfied with the execution result and continues the conversation via chat, all subsequent messages will be considered as part of the currently selected Hai task. Once satisfied, the user can manually mark the task as `Completed`.
- User clicks on `Start New Task` button or `plus` icon to start a new task, we are not tracking these tasks to manage tasks status updates.
- On starting a new task, setting currently selected Hai task id to `null` or empty.
- User will be notified once the task marked as `Completed` or if there are any issues while doing so.

#### Task List page changes
- Once the task marked as `Completed`, a green tick mark circle will be shown beside the Hai task ID.


#### Tasks List reading from the file changes
- Currently, we are not traking the `PRD` id while reading the tasks from the specifications folder. 
- Added `PRD` id to the feature object to track which task is executed and to update the status.


<!-- Describe your changes in detail. What problem does this PR solve? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)

### Screenshots
Confirmation prompt
<img width="418" alt="image" src="https://github.com/user-attachments/assets/e26b910b-e186-4664-beb7-38d2506785c8" />

Not showing the confirmation prompt for new task/chat
<img width="445" alt="image" src="https://github.com/user-attachments/assets/ae811cde-1d18-48ee-9cb9-1dfd95ef85b6" />

Updating task status in the PRD feature files
<img width="753" alt="image" src="https://github.com/user-attachments/assets/0f528071-7d84-4117-8568-7439caf97ef6" />

Notification shown to the users upon successful status updates
<img width="1209" alt="image" src="https://github.com/user-attachments/assets/07ff0919-a915-428b-97c5-b44ea73cea0e" />

Showing the task status in Hai-Task list component
<img width="566" alt="image" src="https://github.com/user-attachments/assets/159e0fcb-0b46-4cb2-87cf-03c9ac25b45a" />

<!-- For UI changes, add screenshots here -->
