### PR TITLE
fix: rename plan_mode_response to plan_mode_respond

### DIFF
--- a/.changeset/modern-spies-explain.md
+++ b/.changeset/modern-spies-explain.md
@@ -1,0 +1,5 @@
+---
+"hai-build-code-generator": patch
+---
+
+fix plan mode tool name issue with plan_mode_response

--- a/src/core/prompts/system.hai.v1.ts
+++ b/src/core/prompts/system.hai.v1.ts
@@ -234,14 +234,14 @@ Your final result description here
 <command>Command to demonstrate result (optional)</command>
 </attempt_completion>
 
-## plan_mode_response
+## plan_mode_respond
 Description: Use this tool in PLAN MODE to respond to user inquiries about planning a task. If not in PLAN MODE (as indicated by environment_details), do not use this tool.
 Parameters:
 - response: (required) The response to provide to the user. Do not try to use tools in this parameter, this is simply a chat response.
 Usage:
-<plan_mode_response>
+<plan_mode_respond>
 <response>Your response here</response>
-</plan_mode_response>
+</plan_mode_respond>
 
 # Tool Use Examples
 
@@ -476,11 +476,11 @@ ACT MODE V.S. PLAN MODE
 
 In each user message, the environment_details will specify the current mode. There are two modes:
 
-- ACT MODE: In this mode, you have access to all tools EXCEPT the plan_mode_response tool.
+- ACT MODE: In this mode, you have access to all tools EXCEPT the plan_mode_respond tool.
  - In ACT MODE, you use tools to accomplish the user's task. Once you've completed the user's task, you use the attempt_completion tool to present the result of the task to the user.
-- PLAN MODE: In this special mode, you have access to the plan_mode_response tool.
+- PLAN MODE: In this special mode, you have access to the plan_mode_respond tool.
  - In PLAN MODE, the goal is to gather information and get context to create a detailed plan for accomplishing the task, which the user will review and approve before they switch you to ACT MODE to implement the solution.
- - In PLAN MODE, when you need to converse with the user or present a plan, you should use the plan_mode_response tool to deliver your response directly, rather than using <thinking> tags to analyze when to respond. Do not talk about using plan_mode_response - just use it directly to share your thoughts and provide helpful answers.
+ - In PLAN MODE, when you need to converse with the user or present a plan, you should use the plan_mode_respond tool to deliver your response directly, rather than using <thinking> tags to analyze when to respond. Do not talk about using plan_mode_respond - just use it directly to share your thoughts and provide helpful answers.
 
 ## What is PLAN MODE?
 

--- a/src/core/prompts/system.hai.v2.ts
+++ b/src/core/prompts/system.hai.v2.ts
@@ -253,14 +253,14 @@ Your final result description here
 <command>Command to demonstrate result (optional)</command>
 </attempt_completion>
 
-## plan_mode_response
+## plan_mode_respond
 Description: Respond to the user's inquiry in an effort to plan a solution to the user's task. This tool should be used when you need to provide a response to a question or statement from the user about how you plan to accomplish the task. This tool is only available in PLAN MODE. The environment_details will specify the current mode, if it is not PLAN MODE then you should not use this tool. Depending on the user's message, you may ask questions to get clarification about the user's request, architect a solution to the task, and to brainstorm ideas with the user. For example, if the user's task is to create a website, you may start by asking some clarifying questions, then present a detailed plan for how you will accomplish the task given the context, and perhaps engage in a back and forth to finalize the details before the user switches you to ACT MODE to implement the solution.
 Parameters:
 - response: (required) The response to provide to the user. Do not try to use tools in this parameter, this is simply a chat response.
 Usage:
-<plan_mode_response>
+<plan_mode_respond>
 <response>Your response here</response>
-</plan_mode_response>
+</plan_mode_respond>
 
 # Tool Use Examples
 
@@ -528,16 +528,16 @@ ACT MODE vs. PLAN MODE
 Each user message includes \`environment_details\` specifying the mode:
 
 ACT MODE:
-- Access to all tools **except** \`plan_mode_response\`.
+- Access to all tools **except** \`plan_mode_respond\`.
 - Use tools to complete tasks.
 - Once done, use \`attempt_completion\` to present results.
 
 PLAN MODE
-- Access to \`plan_mode_response\`.
+- Access to \`plan_mode_respond\`.
 - Used for gathering context and creating a detailed plan before execution.
 - Engage in back-and-forth with the user, asking clarifying questions if needed.
 - Use tools like \`read_file\` or \`search_files\` for context gathering.
-- Present plans using \`plan_mode_response\` (avoid \`<thinking>\` for responses).
+- Present plans using \`plan_mode_respond\` (avoid \`<thinking>\` for responses).
 - Include **Mermaid diagrams** when helpful for clarity.
 - Once the plan is finalized, prompt the user to switch back to ACT MODE for execution.
 

--- a/src/core/prompts/system.hai.v3.ts
+++ b/src/core/prompts/system.hai.v3.ts
@@ -235,14 +235,14 @@ Your final result description here
 <command>Command to demonstrate result (optional)</command>
 </attempt_completion>
 
-## plan_mode_response
+## plan_mode_respond
 Description: Use this tool in PLAN MODE to respond to user inquiries about planning a task. If not in PLAN MODE (as indicated by environment_details), do not use this tool.
 Parameters:
 - response: (required) The response to provide to the user. Do not try to use tools in this parameter, this is simply a chat response.
 Usage:
-<plan_mode_response>
+<plan_mode_respond>
 <response>Your response here</response>
-</plan_mode_response>
+</plan_mode_respond>
 
 # Tool Use Examples
 
@@ -478,16 +478,16 @@ ACT MODE vs. PLAN MODE
 Each user message includes \`environment_details\` specifying the mode:
 
 ACT MODE:
-- Access to all tools **except** \`plan_mode_response\`.
+- Access to all tools **except** \`plan_mode_respond\`.
 - Use tools to complete tasks.
 - Once done, use \`attempt_completion\` to present results.
 
 PLAN MODE
-- Access to \`plan_mode_response\`.
+- Access to \`plan_mode_respond\`.
 - Used for gathering context and creating a detailed plan before execution.
 - Engage in back-and-forth with the user, asking clarifying questions if needed.
 - Use tools like \`read_file\` or \`search_files\` for context gathering.
-- Present plans using \`plan_mode_response\` (avoid \`<thinking>\` for responses).
+- Present plans using \`plan_mode_respond\` (avoid \`<thinking>\` for responses).
 - Include **Mermaid diagrams** when helpful for clarity.
 - Once the plan is finalized, prompt the user to switch back to ACT MODE for execution.
 


### PR DESCRIPTION
### Description

fixes rename plan_mode_response to plan_mode_respond due to upstream tool changes introduced in https://github.com/presidio-oss/cline-based-code-generator/pull/88/files#diff-ec5bfb97fa984921dcb420c3fcf9747854c3302ac5ec437f1fe604ee68fc4e7a

<!-- Describe your changes in detail. What problem does this PR solve? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->
