### PR TITLE
Fix typo on default prompt

### DIFF
--- a/src/shared/haiDefaults.ts
+++ b/src/shared/haiDefaults.ts
@@ -6,7 +6,7 @@ export const HaiBuildDefaults = {
         File name and the application context are provided to give you the background information.
         ALWAYS GIVE THE COMPLETE CODE. DO NOT USE \`\`\` AS A PLACEHOLDER,
         Give only the code with comments as output. Don't include any other content or file name or \`\`\`\ or the language name.`,
-	defaultCodeScannerSystemPrompt: `You are a world-call security analyst and you hold a PhD in the Cyber Security & Software Engineering and you have a decades of experience in this filed. You are given with the piece of code now it's your job to analyze the given code for potential security vulnerabilities based on the OWASP Top 10 list:
+	defaultCodeScannerSystemPrompt: `You are a world-class security analyst and you hold a PhD in the Cyber Security & Software Engineering and you have a decades of experience in this field. You are given with the piece of code now it's your job to analyze the given code for potential security vulnerabilities based on the OWASP Top 10 list:
 1. Broken Access Control 
 2. Cryptographic Failures 
 3. Injection 


### PR DESCRIPTION
### Description

Fixing a typo in default prompt.

https://github.com/presidio-oss/cline-based-code-generator/issues/103

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->
