### PR TITLE
fix: fixed inline edit not working

### DIFF
--- a/.changeset/sharp-eels-accept.md
+++ b/.changeset/sharp-eels-accept.md
@@ -1,0 +1,5 @@
+---
+"hai-build-code-generator": patch
+---
+
+Fixed inline edit not working after cline latest merge (v3.8.6)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -257,14 +257,11 @@ export function activate(context: vscode.ExtensionContext) {
 	}
 	context.subscriptions.push(vscode.window.registerUriHandler({ handleUri }))
 
-	const inlineEditingInstance = WebviewProvider.getVisibleInstance()
-	if (inlineEditingInstance) {
-		getAllExtensionState(inlineEditingInstance.controller.context, getWorkspaceID() || "").then(({ apiConfiguration }) => {
-			context.subscriptions.push(
-				...new InlineEditingProvider().withContext(context).withApiConfiguration(apiConfiguration).build(),
-			)
-		})
-	}
+	getAllExtensionState(sidebarWebview.controller.context, getWorkspaceID() || "").then(({ apiConfiguration }) => {
+		context.subscriptions.push(
+			...new InlineEditingProvider().withContext(context).withApiConfiguration(apiConfiguration).build(),
+		)
+	})
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand("hai.haiBuildTaskListClicked", (webview: any) => {


### PR DESCRIPTION
### Description

Fixed inline editing issue in versions 3.3.1 and above

Reason and Fix:
The `WebviewProvider.getVisibleInstance()` returned undefined during startup. To resolve this, the `sidebarWebview` instance was used directly to access the controller.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)

### Screenshots

![image](https://github.com/user-attachments/assets/2a77ca39-117d-4125-b0ab-9a4136e8515d)
![image](https://github.com/user-attachments/assets/c9db7006-258b-4456-b61b-b828c14de132)

