### PR TITLE
fix: included experts directory in build for default expert loading

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -45,6 +45,9 @@ docs/**
 !node_modules/@vscode/codicons/dist/codicon.css
 !node_modules/@vscode/codicons/dist/codicon.ttf
 
+#Include default experts folder
+!src/experts
+
 # Include default themes JSON files used in getTheme
 !src/integrations/theme/default-themes/**
 


### PR DESCRIPTION
### Description

Included the experts folder in .vscodeignore so that it will be preserved during the build process and used to load the default experts in the application.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)




