### PR TITLE
fix: render actual content instead of HTML when highlighting search terms in stories or tasks

### DIFF
--- a/webview-ui/src/components/hai/HaiStoryAccordion.tsx
+++ b/webview-ui/src/components/hai/HaiStoryAccordion.tsx
@@ -3,17 +3,24 @@ import { IHaiClineTask, IHaiTask, IHaiStory } from "../../interfaces/hai-task.in
 import HaiTaskComponent from "./HaiTaskComponent"
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 
+// Interface for the highlighted task structure
+interface IHighlightedHaiTask {
+	original: IHaiTask
+	highlighted: IHaiTask
+}
+
 interface HaiStoryAccordionProps {
 	onTaskClick: (task: IHaiTask) => void
 	onStoryClick: (story: IHaiStory) => void
 	name: string
 	description: string
-	tasks: IHaiTask[]
+	tasks: IHighlightedHaiTask[]
 	onTaskSelect: (task: IHaiClineTask) => void
 	id: string
 	prdId: string
 	storyTicketId?: string
 	isAllExpanded: boolean
+	originalStory: IHaiStory
 }
 
 export const HaiStoryAccordion: React.FC<HaiStoryAccordionProps> = ({
@@ -27,6 +34,7 @@ export const HaiStoryAccordion: React.FC<HaiStoryAccordionProps> = ({
 	id,
 	prdId,
 	isAllExpanded,
+	originalStory,
 }) => {
 	const [isExpanded, setIsExpanded] = useState<boolean>(true)
 
@@ -135,10 +143,7 @@ export const HaiStoryAccordion: React.FC<HaiStoryAccordionProps> = ({
 							/>
 						</div>
 					</div>
-					<VSCodeButton
-						appearance="icon"
-						title="View Story"
-						onClick={() => onStoryClick({ id, prdId, name, description, storyTicketId, tasks })}>
+					<VSCodeButton appearance="icon" title="View Story" onClick={() => onStoryClick(originalStory)}>
 						<span
 							className="codicon codicon-eye"
 							style={{
@@ -164,7 +169,7 @@ export const HaiStoryAccordion: React.FC<HaiStoryAccordionProps> = ({
 								boxSizing: "border-box",
 							}}>
 							{tasks.map((task) => (
-								<div key={task.id}>
+								<div key={task.original.id}>
 									<div>
 										<HaiTaskComponent
 											id={id}

--- a/webview-ui/src/components/hai/HaiTaskComponent.tsx
+++ b/webview-ui/src/components/hai/HaiTaskComponent.tsx
@@ -3,12 +3,18 @@ import { IHaiClineTask, IHaiTask } from "../../interfaces/hai-task.interface"
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 import CopyClipboard from "../common/CopyClipboard"
 
+// Interface for the highlighted task structure
+interface IHighlightedHaiTask {
+	original: IHaiTask
+	highlighted: IHaiTask
+}
+
 interface HaiTaskComponentProps {
 	id: string
 	prdId: string
 	name: string
 	description: string
-	task: IHaiTask
+	task: IHighlightedHaiTask
 	onTaskClick: (task: IHaiTask) => void
 	onTaskSelect: (task: IHaiClineTask) => void
 }
@@ -52,8 +58,8 @@ const HaiTaskComponent: React.FC<HaiTaskComponentProps> = ({ id, prdId, name, de
 							fontWeight: "bold",
 							color: "var(--vscode-descriptionForeground)",
 						}}>
-						<span dangerouslySetInnerHTML={{ __html: task.id }} />
-						{task.subTaskTicketId && (
+						<span dangerouslySetInnerHTML={{ __html: task.highlighted.id }} />
+						{task.highlighted.subTaskTicketId && (
 							<span
 								style={{
 									fontSize: "12px",
@@ -62,12 +68,12 @@ const HaiTaskComponent: React.FC<HaiTaskComponentProps> = ({ id, prdId, name, de
 									textOverflow: "ellipsis",
 								}}
 								dangerouslySetInnerHTML={{
-									__html: ` • ${task.subTaskTicketId}`,
+									__html: ` • ${task.highlighted.subTaskTicketId}`,
 								}}
 							/>
 						)}{" "}
 					</span>
-					{task.status === "Completed" && (
+					{task.original.status === "Completed" && (
 						<span
 							className={`codicon codicon-pass-filled`}
 							style={{ marginLeft: "4px", color: "green", fontSize: "13px" }}
@@ -83,7 +89,7 @@ const HaiTaskComponent: React.FC<HaiTaskComponentProps> = ({ id, prdId, name, de
 						wordBreak: "break-word",
 						overflowWrap: "anywhere",
 					}}
-					dangerouslySetInnerHTML={{ __html: task.list }}
+					dangerouslySetInnerHTML={{ __html: task.highlighted.list }}
 				/>
 			</div>
 
@@ -99,8 +105,8 @@ const HaiTaskComponent: React.FC<HaiTaskComponentProps> = ({ id, prdId, name, de
 					onClick={() => {
 						onTaskSelect({
 							context: `${name}: ${description}`,
-							...task,
-							id: `${prdId}-${id}-${task.id}`,
+							...task.original,
+							id: `${prdId}-${id}-${task.original.id}`,
 						})
 					}}>
 					<span className="codicon codicon-play" style={{ fontSize: 14, cursor: "pointer" }} />
@@ -108,10 +114,10 @@ const HaiTaskComponent: React.FC<HaiTaskComponentProps> = ({ id, prdId, name, de
 				<CopyClipboard
 					title="Copy Task"
 					onCopyContent={() => {
-						return `Task (${task.id}): ${task.list}\nAcceptance: ${task.acceptance}\n\nContext:\nStory (${id}): ${name}\nStory Acceptance: ${description}\n`
+						return `Task (${task.original.id}): ${task.original.list}\nAcceptance: ${task.original.acceptance}\n\nContext:\nStory (${id}): ${name}\nStory Acceptance: ${description}\n`
 					}}
 				/>
-				<VSCodeButton appearance="icon" title="View Task" onClick={() => onTaskClick(task)}>
+				<VSCodeButton appearance="icon" title="View Task" onClick={() => onTaskClick(task.original)}>
 					<span className="codicon codicon-eye" style={{ fontSize: 14, cursor: "pointer" }} />
 				</VSCodeButton>
 			</div>


### PR DESCRIPTION
### Description

- Fixes an issue where search term highlighting caused raw HTML to render instead of the actual content in stories and tasks

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

<img width="459" alt="Screenshot 2025-04-25 at 8 33 12 PM" src="https://github.com/user-attachments/assets/540fb982-39fc-425b-9239-742e63c6293d" />
<img width="400" alt="Screenshot 2025-04-25 at 8 33 32 PM" src="https://github.com/user-attachments/assets/afdb8499-aabf-4976-bbe8-3e56ed2f158c" />