### PR TITLE
fix : expert icon rendering with fallback to default icon

### DIFF
--- a/.changeset/happy-seals-roll.md
+++ b/.changeset/happy-seals-roll.md
@@ -1,0 +1,5 @@
+---
+"hai-build-code-generator": patch
+---
+
+Fix expert icon rendering to properly display image or fallback to a default icon.

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1297,10 +1297,15 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 									onClick={handleExpertsButtonClick}
 									tabIndex={0}>
 									<ExpertsButtonContent>
-										{selectedExpert && selectedExpert.iconComponent && (
+										{selectedExpert && selectedExpert.iconComponent ? (
 											<div style={{ width: "12px", height: "12px", display: "flex", alignItems: "center" }}>
-												<selectedExpert.iconComponent />
+												<img src={selectedExpert.iconComponent} alt={`${selectedExpert.name} icon`} />
 											</div>
+										) : (
+											<span
+												className="codicon codicon-person"
+												style={{ fontSize: "12px", width: "12px", height: "12px" }}
+											/>
 										)}
 										{selectedExpert ? selectedExpert.name : "Default"}
 									</ExpertsButtonContent>


### PR DESCRIPTION
### Description

- Fixed expert icon rendering to prevent application crash when iconComponent is missing, with fallback to default person icon

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)