### PR TITLE
fix : quick action tile

### DIFF
--- a/.changeset/hungry-timers-happen.md
+++ b/.changeset/hungry-timers-happen.md
@@ -1,0 +1,5 @@
+---
+"hai-build-code-generator": patch
+---
+
+Fixes an issue where clicking on chat-related quick action tiles did not populate the message input with the corresponding task. The message input now correctly reflects the selected chat operation.

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -103,9 +103,7 @@ const ChatView = ({
 
 	useEffect(() => {
 		// eslint-disable-next-line @typescript-eslint/no-unused-expressions
-		selectedHaiTask &&
-			selectedHaiTask?.id &&
-			setInputValue(`Task: ${selectedHaiTask.list} ${selectedHaiTask.acceptance} ${selectedHaiTask.context}`)
+		selectedHaiTask && setInputValue(`Task: ${selectedHaiTask.list} ${selectedHaiTask.acceptance} ${selectedHaiTask.context}`)
 	}, [selectedHaiTask])
 
 	useDeepCompareEffect(() => {


### PR DESCRIPTION
### Description

- Resolved an issue where clicking on chat-related quick action tiles did not populate the message input with the corresponding task.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="497" alt="Screenshot 2025-05-04 at 9 14 32 PM" src="https://github.com/user-attachments/assets/39422c2a-cab5-43ba-a4e0-00f0815373b2" />

