### PR TITLE
Fix/openai config validation fix

### DIFF
--- a/.changeset/fast-ways-draw.md
+++ b/.changeset/fast-ways-draw.md
@@ -1,0 +1,5 @@
+---
+"hai-build-code-generator": patch
+---
+
+Fixing LLM configuration validation

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -15,7 +15,7 @@ export class OpenAiHandler implements ApiHandler {
 	constructor(options: ApiHandlerOptions) {
 		this.options = options
 		// Azure API shape slightly differs from the core API shape: https://github.com/openai/openai-node?tab=readme-ov-file#microsoft-azure-openai
-		if (this.options.openAiBaseUrl?.toLowerCase().includes("azure.com")) {
+		if (this.options.openAiBaseUrl?.toLowerCase().includes("azure")) {
 			this.client = new AzureOpenAI({
 				endpoint: this.options.openAiBaseUrl,
 				deployment: this.options.openAiModelId,
@@ -107,7 +107,7 @@ export class OpenAiHandler implements ApiHandler {
 
 	async validateAPIKey(): Promise<boolean> {
 		try {
-			if (this.options.openAiBaseUrl?.toLowerCase().includes("azure.com") && !this.options.openAiModelId) {
+			if (this.options.openAiBaseUrl?.toLowerCase().includes("azure") && !this.options.openAiModelId) {
 				return false
 			}
 


### PR DESCRIPTION
### Description
When using OpenAI services as part of Azure Gov Cloud subscriptions, the credentials are not accepted during configuration — the LLM configuration validation in the HAI Build plugin fails.

Reason:
The OpenAI service deployments included in Azure Gov subscriptions have base URLs that end with .us. For example, the endpoint would be https://example.openai.azure.us/, whereas in commercial subscriptions, the base URL uses .com.

Fix: Instead of looking for "azure.com" while figuring out if it is an OpenAI-compatible Azure service, now we look for "azure". 


### Bug Fix

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)


