### PR TITLE
fix: prevent unnecessary find_relevant_files tool call

### DIFF
--- a/.changeset/long-coats-swim.md
+++ b/.changeset/long-coats-swim.md
@@ -1,0 +1,5 @@
+---
+"hai-build-code-generator": patch
+---
+
+Clarified usage guidelines for the `find_relevant_files` tool to prevent it from triggering on non-task-related queries. This improves response relevance, reduces latency, and avoids unnecessary tool invocations for general or unrelated input.

--- a/src/core/prompts/custom.ts
+++ b/src/core/prompts/custom.ts
@@ -30,8 +30,9 @@ export const customCapabilitiesPrompt = (enabled: boolean) =>
 	!enabled
 		? ""
 		: `
-- The initial list of of all filepaths given to you inside environment_details is not-exhaustive; it may not include all possible files or directories. So when the user initially gives you a task, you should consider using the \`find_relevant_files\` tool to locate the relevant files, so the probability of finding the most relevant files apart from the initial list of filepaths provided is higher since the initial list may not cover all possibilities.
-- You should always use the \`find_relevant_files\` tool when the user initially provide the task. Even though the initial list of filepaths given inside the environment_details may sufficient to get the tak done, you should prioritize finding the most relevant files for the task at hand before using any other tools. This ensures that you are working with the most accurate and up-to-date information available, which can lead to better outcomes for the user's task. If \`find_relevant_files\` the tool returns an empty list of files, you can ignore the result and continue with the task.
+- The initial list of all filepaths given to you inside environment_details is not-exhaustive; it may not include all possible files or directories. When the user presents a code-related task that requires file access or understanding existing code, consider using the \`find_relevant_files\` tool to locate the relevant files.
+- Only use the \`find_relevant_files\` tool when the user's request is specifically related to code, development, file operations, or understanding the codebase. For general questions, conversational queries, or non-code-related requests, avoid using this tool.
+- If \`find_relevant_files\` the tool returns an empty list of files, you can ignore the result and continue with the task.
 - You should always use the \`code_security_scan\` tool before whenever you use the tool \`attempt_completion\` to ensure the generated code is secure and free from vulnerabilities, don't assume that the code is free from vulnerabilities you should prioritize security scan before attempting to complete the task. If there any vulnerabilities found, you must address them before completing the task. Before fixing the vulnerabilities, you should always get the user's approval before proceeding with the fixing process.
 - Always ensure that the code you generate adheres to best practices and security standards to minimize risks and vulnerabilities.
 `
@@ -40,7 +41,13 @@ export const customRulesPrompt = (enabled: boolean) =>
 	!enabled
 		? ""
 		: `
-- The first tool you use when the user gives the task must be \`find_relevant_files\` to locate the most relevant files for the task.Failure to do so may result in incomplete or inaccurate information being used for the task. Always prioritize finding the most relevant files to ensure the best results. If \`find_relevant_files\` the tool returns an empty list of files, you can ignore the result and continue with the task.
+- For code-related tasks that involve modifying, creating, or understanding files in the codebase, use \`find_relevant_files\` first to identify the most relevant context. Do NOT use this tool for general questions, explanations, or non-code-related queries.
+- When determining if a query requires the \`find_relevant_files\` tool, consider:
+  * Does the query require knowledge about specific files in the codebase?
+  * Is the user asking about implementing, modifying, or debugging code?
+  * Does the user mention specific files, directories, or code components?
+  * Is file context necessary to provide an appropriate response?
+  If the answer is no to these questions, skip using the tool and respond directly.
 - You should always use the \`code_security_scan\` tool before attempting to complete any code-related tasks to ensure security and compliance with best practices. Failure to perform a security scan may expose the code to vulnerabilities and security risks. Always prioritize security and compliance with best practices. If any issue or vulnerabilities are found, address them before proceeding with the task.
 - While fixing the vulnerabilities do not remove any of the working code only replace the implementation that is affected with the vulnerabilities, if you require anymore information or course correction, consult with the user before proceeding to apply any of the change. Always show the plan before fixing the security vulnerabilities. Before fixing the vulnerabilities, you should always get the user's approval before proceeding with the fixing process.
 `

--- a/src/embedding/providers/openai.ts
+++ b/src/embedding/providers/openai.ts
@@ -8,7 +8,7 @@ export class OpenAiEmbeddingHandler implements EmbeddingHandler {
 
 	constructor(options: EmbeddingHandlerOptions) {
 		this.options = options
-		if (this.options.openAiBaseUrl?.toLowerCase().includes("azure.com")) {
+		if (this.options.openAiBaseUrl?.toLowerCase().includes("azure")) {
 			const originalURL = new URL(this.options.openAiBaseUrl)
 			const baseURL = originalURL.origin
 


### PR DESCRIPTION
### Description

- Revised the guidelines and usage prompt for the find_relevant_files tool to clarify that it should be used when the query pertains to the current project and not for general queries.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="342" alt="Screenshot 2025-05-06 at 3 48 06 PM" src="https://github.com/user-attachments/assets/c67e2ed6-3ba9-4707-8f3c-922f525c6f3b" />
