### PR TITLE
fix : default prompt cache

### DIFF
--- a/.changeset/serious-queens-fry.md
+++ b/.changeset/serious-queens-fry.md
@@ -1,0 +1,5 @@
+---
+"hai-build-code-generator": patch
+---
+
+Enablement of prompt cache by default may cause minor issues in some scenarios.

--- a/src/core/storage/state.ts
+++ b/src/core/storage/state.ts
@@ -361,7 +361,7 @@ export async function getAllExtensionState(context: vscode.ExtensionContext, wor
 			awsSessionToken,
 			awsRegion,
 			awsUseCrossRegionInference,
-			awsBedrockUsePromptCache: awsBedrockUsePromptCache ?? true,
+			awsBedrockUsePromptCache,
 			awsBedrockEndpoint,
 			awsProfile,
 			awsUseProfile,

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -688,7 +688,7 @@ const ApiOptions = ({ showModelOptions, showModelError = true, isPopup, onValid 
 						{selectedModelInfo.supportsPromptCache && (
 							<>
 								<VSCodeCheckbox
-									checked={apiConfiguration?.awsBedrockUsePromptCache ?? true}
+									checked={apiConfiguration?.awsBedrockUsePromptCache || false}
 									onChange={(e: any) => {
 										const isChecked = e.target.checked === true
 										setApiConfiguration({


### PR DESCRIPTION
### Description

Enablement of prompt cache by default may cause minor issues in some scenarios.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)
