### PR TITLE
fix: send report preference

### DIFF
--- a/.changeset/seven-jeans-watch.md
+++ b/.changeset/seven-jeans-watch.md
@@ -1,0 +1,5 @@
+---
+"hai-build-code-generator": patch
+---
+
+Store usage report preference globally to avoid asking the survey repeatedly in new projects.

--- a/src/core/storage/state.ts
+++ b/src/core/storage/state.ts
@@ -46,6 +46,7 @@ export function isCustomGlobalKey(key: string): boolean {
 		"embeddingAzureOpenAIApiVersion",
 		"embeddingOllamaBaseUrl",
 		"embeddingOllamaModelId",
+		"telemetrySetting",
 	]
 	return customGlobalKeys.includes(key)
 }
@@ -275,7 +276,7 @@ export async function getAllExtensionState(context: vscode.ExtensionContext, wor
 		customGetState(context, "previousModeThinkingBudgetTokens") as Promise<number | undefined>,
 		customGetState(context, "qwenApiLine") as Promise<string | undefined>,
 		customGetSecret(context, "liteLlmApiKey", workspaceId) as Promise<string | undefined>,
-		customGetState(context, "telemetrySetting") as Promise<TelemetrySetting | undefined>,
+		getGlobalState(context, "telemetrySetting") as Promise<TelemetrySetting | undefined>,
 		customGetSecret(context, "asksageApiKey", workspaceId) as Promise<string | undefined>,
 		customGetState(context, "asksageApiUrl") as Promise<string | undefined>,
 		customGetSecret(context, "xaiApiKey", workspaceId) as Promise<string | undefined>,
@@ -599,7 +600,6 @@ export async function updateEmbeddingConfiguration(
 	await customUpdateState(context, "embeddingOllamaModelId", ollamaModelId)
 	// Update Secrets
 	await customStoreSecret(context, "embeddingAwsAccessKey", workspaceId, awsAccessKey, true)
-	await customStoreSecret(context, "embeddingAwsSecretKey", workspaceId, awsSecretKey, true)
 	await customStoreSecret(context, "embeddingAwsSecretKey", workspaceId, awsSecretKey, true)
 	await customStoreSecret(context, "embeddingAwsSessionToken", workspaceId, awsSessionToken, true)
 	await customStoreSecret(context, "embeddingOpenAiApiKey", workspaceId, openAiApiKey, true)

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -250,7 +250,7 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 					<VSCodeCheckbox
 						style={{ marginBottom: "5px" }}
 						checked={telemetrySetting === "enabled"}
-						onChange={(e: any) => {
+						onClick={(e: any) => {
 							const checked = e.target.checked === true
 							setTelemetrySetting(checked ? "enabled" : "disabled")
 						}}>


### PR DESCRIPTION
### Description

Storing the usage report preference globally to avoid prompting the user for it in every new project. This improves user experience by respecting their initial choice across all projects.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)
