### PR TITLE
fix: save button implementation in settings

### DIFF
--- a/.changeset/perfect-mugs-hope.md
+++ b/.changeset/perfect-mugs-hope.md
@@ -1,0 +1,5 @@
+---
+"hai-build-code-generator": patch
+---
+
+Replace AutoSave with a 'Done' button in settings to explicitly save configuration changes, improving clarity and user control.

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -881,9 +881,6 @@ export class Controller {
 			case "validateLLMConfig":
 				let isValid = false
 				if (message.apiConfiguration) {
-					// Save the LLM configuration in the state
-					await updateApiConfiguration(this.context, message.apiConfiguration, this.workspaceId)
-
 					// If no validation error is encountered, validate the LLM configuration by sending a test message.
 					if (!message.text) {
 						try {
@@ -906,9 +903,6 @@ export class Controller {
 			case "validateEmbeddingConfig":
 				let isEmbeddingValid = false
 				if (message.embeddingConfiguration) {
-					// Save the Embedding configuration in the state
-					await updateEmbeddingConfiguration(this.context, message.embeddingConfiguration, this.workspaceId)
-
 					// If no validation error is encountered, validate the Embedding configuration by sending a test message.
 					if (!message.text) {
 						try {

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -37,7 +37,7 @@ interface ChatViewProps {
 	showAnnouncement: boolean
 	hideAnnouncement: () => void
 	showHistoryView: () => void
-	onTaskSelect: (task: IHaiClineTask) => void
+	onTaskSelect: (task: IHaiClineTask | null) => void
 	selectedHaiTask: IHaiClineTask | null
 	haiConfig: {
 		[x: string]: any
@@ -809,13 +809,7 @@ const ChatView = ({
 	)
 
 	const clearSelectedHaiTaskId = () => {
-		onTaskSelect({
-			acceptance: selectedHaiTask?.acceptance ?? "",
-			context: selectedHaiTask?.context ?? "",
-			id: "",
-			list: selectedHaiTask?.list ?? "",
-			status: selectedHaiTask?.status ?? "",
-		})
+		onTaskSelect(null)
 	}
 
 	return (

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -7,7 +7,6 @@ import ApiOptions from "./ApiOptions"
 import SettingsViewExtra from "./SettingsViewExtra"
 import EmbeddingOptions from "./EmbeddingOptions"
 import SettingsButton from "../common/SettingsButton"
-import { useDeepCompareEffect } from "react-use"
 import { CREATE_HAI_RULES_PROMPT, HAI_RULES_PATH } from "../../utils/constants"
 import { TabButton } from "../mcp/McpView"
 
@@ -63,16 +62,14 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 		}
 	}
 
-	const handleSubmit = () => {
+	const handleSubmit = (withoutDone: boolean = false) => {
 		const apiValidationResult = validateApiConfiguration(apiConfiguration)
 		const modelIdValidationResult = validateModelId(apiConfiguration, openRouterModels)
-		const embeddingValidationResult = validateEmbeddingConfiguration(embeddingConfiguration)
 
 		if (!apiValidationResult && !modelIdValidationResult) {
 			vscode.postMessage({ type: "apiConfiguration", apiConfiguration })
 			vscode.postMessage({ type: "buildContextOptions", buildContextOptions: buildContextOptions })
 			vscode.postMessage({ type: "embeddingConfiguration", embeddingConfiguration })
-			onDone()
 		}
 
 		vscode.postMessage({
@@ -81,6 +78,10 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 			customInstructionsSetting: customInstructions,
 			telemetrySetting,
 		})
+
+		if (!withoutDone) {
+			onDone()
+		}
 	}
 
 	useEffect(() => {
@@ -94,15 +95,12 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 		}
 	}, [pendingTabChange])
 
-	useDeepCompareEffect(() => {
-		vscode.postMessage({ type: "buildContextOptions", buildContextOptions: buildContextOptions })
-	}, [buildContextOptions])
-
 	const handleTabChange = (tab: "plan" | "act") => {
 		if (tab === chatSettings.mode) {
 			return
 		}
 		setPendingTabChange(tab)
+		handleSubmit(true)
 	}
 
 	return (
@@ -127,7 +125,7 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 					paddingRight: 17,
 				}}>
 				<h3 style={{ color: "var(--vscode-foreground)", margin: 0 }}>Settings</h3>
-				<VSCodeButton onClick={handleSubmit}>Done</VSCodeButton>
+				<VSCodeButton onClick={() => handleSubmit(false)}>Done</VSCodeButton>
 			</div>
 			<div
 				style={{


### PR DESCRIPTION
### Description

Update the settings interface to remove autosave functionality and introduce a 'Done' button that users can click to confirm and save their changes. This will improve the user experience by making the save action more deliberate and visible.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="311" alt="Screenshot 2025-05-09 at 2 54 45 AM" src="https://github.com/user-attachments/assets/f49bf4ac-3e1a-4ee2-823c-f50dc6abb8cf" />

