### PR TITLE
fix: navigation issue

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -67,11 +67,13 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand("hai.mcpButtonClicked", (webview: any) => {
-			const openMcp = (instance?: WebviewProvider) =>
+			const openMcp = (instance?: WebviewProvider) => {
+				instance?.controller.postStateToWebview()
 				instance?.controller.postMessageToWebview({
 					type: "action",
 					action: "mcpButtonClicked",
 				})
+			}
 			const isSidebar = !webview
 			if (isSidebar) {
 				openMcp(WebviewProvider.getSidebarInstance())
@@ -140,6 +142,7 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand("hai.historyButtonClicked", (webview: any) => {
 			WebviewProvider.getAllInstances().forEach((instance) => {
 				const openHistory = async (instance?: WebviewProvider) => {
+					await instance?.controller.postStateToWebview()
 					instance?.controller.postMessageToWebview({
 						type: "action",
 						action: "historyButtonClicked",
@@ -159,6 +162,7 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand("hai.accountButtonClicked", (webview: any) => {
 			WebviewProvider.getAllInstances().forEach((instance) => {
 				const openAccount = async (instance?: WebviewProvider) => {
+					await instance?.controller.postStateToWebview()
 					instance?.controller.postMessageToWebview({
 						type: "action",
 						action: "accountButtonClicked",
@@ -178,6 +182,7 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand("hai.expertsButtonClicked", (webview: any) => {
 			WebviewProvider.getAllInstances().forEach((instance) => {
 				const openExperts = async (instance?: WebviewProvider) => {
+					await instance?.controller.postStateToWebview()
 					instance?.controller.postMessageToWebview({
 						type: "action",
 						action: "expertsButtonClicked",
@@ -267,6 +272,7 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand("hai.haiBuildTaskListClicked", (webview: any) => {
 			WebviewProvider.getAllInstances().forEach((instance) => {
 				const openHaiTaskList = async (instance?: WebviewProvider) => {
+					await instance?.controller.postStateToWebview()
 					await instance?.controller.postMessageToWebview({
 						type: "action",
 						action: "haiBuildTaskListClicked",


### PR DESCRIPTION
### Description

Settings value changes should reflect only after done when moving to another tab

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)