### PR TITLE
fix: Replaced baseUrl with endpoint for AzureOpenAI

### DIFF
--- a/.changeset/lovely-geese-listen.md
+++ b/.changeset/lovely-geese-listen.md
@@ -1,0 +1,5 @@
+---
+"hai-build-code-generator": patch
+---
+
+Fixed deployment name not being passed as separate parameter for AzureOpenAI (OpenAI-Compatible)

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -24,7 +24,6 @@ export class OpenAiHandler implements ApiHandler {
 		) {
 			this.client = new AzureOpenAI({
 				endpoint: this.options.openAiBaseUrl,
-				deployment: this.options.openAiModelId,
 				apiKey: this.options.openAiApiKey,
 				apiVersion: this.options.azureApiVersion || azureOpenAiDefaultApiVersion,
 				defaultHeaders: this.options.openAiHeaders,

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -23,7 +23,8 @@ export class OpenAiHandler implements ApiHandler {
 				!this.options.openAiModelId?.toLowerCase().includes("deepseek"))
 		) {
 			this.client = new AzureOpenAI({
-				baseURL: this.options.openAiBaseUrl,
+				endpoint: this.options.openAiBaseUrl,
+				deployment: this.options.openAiModelId,
 				apiKey: this.options.openAiApiKey,
 				apiVersion: this.options.azureApiVersion || azureOpenAiDefaultApiVersion,
 				defaultHeaders: this.options.openAiHeaders,


### PR DESCRIPTION
### Description

The reason for replacing `baseUrl` with `endpoint` in AzureOpenAI is that when using `baseUrl`, users need to manually append `/openai` to the endpoint `(e.g., https://<azure-domain>.com/openai)`. In contrast, when using `endpoint`, this is handled automatically and the additional path is not required.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)
