### PR TITLE
Add .hai.config to support external overrides for telemetry configuration

### DIFF
--- a/.changeset/new-knives-reflect.md
+++ b/.changeset/new-knives-reflect.md
@@ -1,0 +1,5 @@
+---
+"hai-build-code-generator": minor
+---
+
+Add .hai.config to support external overrides for telemetry configuration

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -263,7 +263,6 @@ export class Controller {
 				await this.postStateToWebview()
 				break
 			case "webviewDidLaunch":
-				await this.updateHaiRulesState()
 				this.postStateToWebview()
 				this.workspaceTracker?.populateFilePaths() // don't await
 				getTheme().then((theme) =>
@@ -741,9 +740,6 @@ export class Controller {
 					type: "ollamaEmbeddingModels",
 					ollamaEmbeddingModels,
 				})
-				break
-			case "checkHaiRules":
-				await this.updateHaiRulesState(true)
 				break
 			case "showToast":
 				switch (message.toast?.toastType) {
@@ -1877,7 +1873,6 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			lastShownAnnouncementId,
 			customInstructions,
 			expertPrompt,
-			isHaiRulesPresent,
 			taskHistory,
 			autoApprovalSettings,
 			browserSettings,
@@ -1907,7 +1902,6 @@ Here is the project's README to help you get started:\n\n${mcpDetails.readmeCont
 			apiConfiguration,
 			customInstructions,
 			expertPrompt,
-			isHaiRulesPresent,
 			uriScheme: vscode.env.uriScheme,
 			currentTaskItem: this.task?.taskId ? (taskHistory || []).find((item) => item.id === this.task?.taskId) : undefined,
 			checkpointTrackerErrorMessage: this.task?.checkpointTrackerErrorMessage,
@@ -2509,21 +2503,6 @@ Commit message:`
 				}
 				await this.postStateToWebview()
 				break
-		}
-	}
-
-	async updateHaiRulesState(postToWebview: boolean = false) {
-		const workspaceFolder = getWorkspacePath()
-		if (!workspaceFolder) {
-			return
-		}
-		const haiRulesPath = path.join(workspaceFolder, GlobalFileNames.clineRules)
-		const isHaiRulePresent = await fileExistsAtPath(haiRulesPath)
-
-		await customUpdateState(this.context, "isHaiRulesPresent", isHaiRulePresent)
-
-		if (postToWebview) {
-			await this.postStateToWebview()
 		}
 	}
 

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -71,6 +71,7 @@ import { deleteFromContextDirectory } from "@utils/delete-helper"
 import { isLocalMcp, getLocalMcpDetails, getLocalMcp, getAllLocalMcps } from "@utils/local-mcp-registry"
 import { getStarCount } from "../../services/github/github"
 import { openFile } from "@integrations/misc/open-file"
+import { posthogClientProvider } from "@/services/posthog/PostHogClientProvider"
 
 /*
 https://github.com/microsoft/vscode-webview-ui-toolkit-samples/blob/main/default/weather-webview/src/providers/WeatherViewProvider.ts
@@ -2504,6 +2505,15 @@ Commit message:`
 				await this.postStateToWebview()
 				break
 		}
+	}
+
+	async updateTelemetryConfig() {
+		// Create new posthost client
+		posthogClientProvider.initPostHogClient()
+
+		// Update langfuse and posthog instance in telemetry
+		telemetryService.initPostHogClient()
+		telemetryService.initLangfuseClient()
 	}
 
 	async updateExpertPrompt(prompt?: string, expertName?: string) {

--- a/src/core/storage/state.ts
+++ b/src/core/storage/state.ts
@@ -212,7 +212,6 @@ export async function getAllExtensionState(context: vscode.ExtensionContext, wor
 		globalClineRulesToggles,
 		requestTimeoutMs,
 		shellIntegrationTimeout,
-		isHaiRulesPresent,
 		buildContextOptions,
 		buildIndexProgress,
 		isApiConfigurationValid,
@@ -314,7 +313,6 @@ export async function getAllExtensionState(context: vscode.ExtensionContext, wor
 		customGetState(context, "globalClineRulesToggles") as Promise<ClineRulesToggles | undefined>,
 		customGetState(context, "requestTimeoutMs") as Promise<number | undefined>,
 		customGetState(context, "shellIntegrationTimeout") as Promise<number | undefined>,
-		customGetState(context, "isHaiRulesPresent") as Promise<boolean | undefined>,
 		customGetState(context, "buildContextOptions") as Promise<HaiBuildContextOptions | undefined>,
 		customGetState(context, "buildIndexProgress") as Promise<HaiBuildIndexProgress | undefined>,
 		customGetState(context, "isApiConfigurationValid") as Promise<boolean | undefined>,
@@ -469,7 +467,6 @@ export async function getAllExtensionState(context: vscode.ExtensionContext, wor
 		lastShownAnnouncementId,
 		customInstructions,
 		expertPrompt,
-		isHaiRulesPresent,
 		taskHistory,
 		buildContextOptions: buildContextOptions
 			? {

--- a/src/global-constants.ts
+++ b/src/global-constants.ts
@@ -7,4 +7,5 @@ export const GlobalFileNames = {
 	clineRules: ".hairules",
 	experts: ".hai-experts",
 	defaultExperts: "src/experts",
+	haiConfig: ".hai.config",
 }

--- a/src/integrations/workspace/HaiFileSystemWatcher.ts
+++ b/src/integrations/workspace/HaiFileSystemWatcher.ts
@@ -28,7 +28,7 @@ class HaiFileSystemWatcher {
 			this.ig.add(
 				content
 					.split("\n")
-					.filter((line) => line.trim() && !line.startsWith("#") && !line.includes(GlobalFileNames.clineRules)),
+					.filter((line) => line.trim() && !line.startsWith("#")),
 			)
 		} catch (error) {
 			console.log("HaiFileSystemWatcher No .gitignore found, using default exclusions.")
@@ -67,11 +67,6 @@ class HaiFileSystemWatcher {
 		this.watcher.on("unlink", (filePath) => {
 			console.log("HaiFileSystemWatcher File deleted", filePath)
 
-			// Check for .hairules
-			if (this.isHaiRulesPath(filePath)) {
-				this.providerRef.deref()?.updateHaiRulesState(true)
-			}
-
 			// Check for the experts
 			if (filePath.includes(GlobalFileNames.experts)) {
 				this.providerRef.deref()?.loadExperts()
@@ -82,11 +77,6 @@ class HaiFileSystemWatcher {
 
 		this.watcher.on("add", (filePath) => {
 			console.log("HaiFileSystemWatcher File added", filePath)
-
-			// Check for .hairules
-			if (this.isHaiRulesPath(filePath)) {
-				this.providerRef.deref()?.updateHaiRulesState(true)
-			}
 
 			// Check for the experts
 			if (filePath.includes(GlobalFileNames.experts)) {
@@ -104,13 +94,6 @@ class HaiFileSystemWatcher {
 			}
 			this.providerRef.deref()?.invokeReindex([filePath], FileOperations.Change)
 		})
-	}
-
-	isHaiRulesPath(path: string) {
-		const pathSplit = path.split(this.sourceFolder)
-		const hairulesPath = pathSplit.length === 2 ? pathSplit[1].replace("/", "") : ""
-
-		return hairulesPath === GlobalFileNames.clineRules
 	}
 
 	async dispose() {

--- a/src/services/posthog/PostHogClientProvider.ts
+++ b/src/services/posthog/PostHogClientProvider.ts
@@ -1,15 +1,26 @@
 import { PostHog } from "posthog-node"
 import { posthogConfig } from "@/shared/services/config/posthog-config"
+import { HaiConfig } from "@/shared/hai-config"
 
-class PostHogClientProvider {
+export class PostHogClientProvider {
 	private static instance: PostHogClientProvider
 	private client: PostHog
 
 	private constructor() {
-		this.client = new PostHog(posthogConfig.apiKey, {
-			host: posthogConfig.host,
+		this.client = this.initPostHogClient()
+	}
+
+	public initPostHogClient() {
+		const config = HaiConfig.getPostHogConfig()
+		const apiKey = config && config.apiKey ? config.apiKey : posthogConfig.apiKey
+		const host = config && config.url ? config.url : posthogConfig.host
+
+		this.client = new PostHog(apiKey, {
+			host,
 			enableExceptionAutocapture: false,
 		})
+
+		return this.client
 	}
 
 	public static getInstance(): PostHogClientProvider {

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -170,7 +170,6 @@ export interface ExtensionState {
 	telemetrySetting: TelemetrySetting
 	shellIntegrationTimeout: number
 	uriScheme?: string
-	isHaiRulesPresent?: boolean
 	userInfo?: {
 		displayName: string | null
 		email: string | null

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -86,7 +86,6 @@ export interface WebviewMessage {
 		| "searchCommits"
 		| "showMcpView"
 		| "fetchLatestMcpServersFromHub"
-		| "checkHaiRules"
 		| "telemetrySetting"
 		| "openSettings"
 		| "updateMcpTimeout"

--- a/src/shared/hai-config.ts
+++ b/src/shared/hai-config.ts
@@ -1,0 +1,86 @@
+import * as fs from "fs"
+import * as path from "path"
+import { z } from "zod"
+import { GlobalFileNames } from "@/global-constants"
+import { getWorkspacePath } from "@/utils/path"
+
+export const haiConfigSchema = z.object({
+	name: z.string().optional(),
+	langfuse: z
+		.object({
+			apiUrl: z.string().trim().optional(),
+			apiKey: z.string().trim().optional(),
+			publicKey: z.string().trim().optional(),
+		})
+		.optional(),
+	posthog: z
+		.object({
+			url: z.string().trim().optional(),
+			apiKey: z.string().trim().optional(),
+		})
+		.optional(),
+})
+
+export class HaiConfig {
+	static getConfig(workspacePath?: string) {
+		if (!workspacePath) {
+			workspacePath = getWorkspacePath()
+		}
+
+		// Parse hai config file
+		const configPath = path.join(workspacePath, GlobalFileNames.haiConfig)
+		if (!fs.existsSync(configPath)) {
+			console.log(`[HaiConfig]: ${configPath} does not exist`)
+			return
+		}
+
+		const content = fs.readFileSync(configPath, "utf-8")
+		const lines = content.split("\n")
+
+		const config: Record<string, any> = {}
+
+		for (const line of lines) {
+			const trimmed = line.trim()
+			if (!trimmed || trimmed.startsWith("#")) {
+				continue
+			}
+
+			const [key, ...rest] = trimmed.split("=")
+			const value = rest.join("=").trim() // supports '=' in value
+
+			const keyParts = key.trim().split(".")
+
+			let current = config
+			for (let i = 0; i < keyParts.length; i++) {
+				const part = keyParts[i]
+				if (i === keyParts.length - 1) {
+					current[part] = value
+				} else {
+					if (!current[part]) {
+						current[part] = {}
+					}
+					current = current[part]
+				}
+			}
+		}
+
+		// Validate the parsed content with schema
+		const { success, data, error } = haiConfigSchema.safeParse(config)
+		if (!success) {
+			console.error(`Error validating ${configPath}, Error: ${error}`)
+			return
+		}
+
+		return data
+	}
+
+	static getPostHogConfig(workspacePath?: string) {
+		const config = HaiConfig.getConfig(workspacePath)
+		return config?.posthog
+	}
+
+	static getLangfuseConfig(workspacePath?: string) {
+		const config = HaiConfig.getConfig(workspacePath)
+		return config?.langfuse
+	}
+}

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -27,7 +27,6 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 		version,
 		customInstructions,
 		setCustomInstructions,
-		isHaiRulesPresent,
 		buildContextOptions,
 		setBuildContextOptions,
 		buildIndexProgress,

--- a/webview-ui/src/components/welcome/WelcomeView.tsx
+++ b/webview-ui/src/components/welcome/WelcomeView.tsx
@@ -16,7 +16,6 @@ const WelcomeView = () => {
 	const handleSubmit = () => {
 		vscode.postMessage({ type: "apiConfiguration", apiConfiguration })
 		vscode.postMessage({ type: "embeddingConfiguration", embeddingConfiguration })
-		vscode.postMessage({ type: "checkHaiRules" })
 	}
 
 	return (

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -67,7 +67,6 @@ export const ExtensionStateContextProvider: React.FC<{
 		version: "",
 		clineMessages: [],
 		taskHistory: [],
-		isHaiRulesPresent: false,
 		shouldShowAnnouncement: false,
 		autoApprovalSettings: DEFAULT_AUTO_APPROVAL_SETTINGS,
 		browserSettings: DEFAULT_BROWSER_SETTINGS,


### PR DESCRIPTION
### Description

This PR introduces support for external telemetry configuration overrides via a `.hai.config` file placed at the root of the workspace.

#### Details

Users can define a `.hai.config` file to override default telemetry settings that may be injected through CI/CD pipelines. This enables environment-specific customization.

Supported override parameters:
```
langfuse.apiUrl=
langfuse.apiKey=
langfuse.publicKey=
posthog.url=
posthog.apiKey=
```
#### Note

- .hai.config is not git-excluded by default. Please ensure sensitive keys are not committed unintentionally.
- The config is parsed at runtime and merged with the default telemetry configuration.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)
