### PR TITLE
doc: updated readme with telemetry override and wiki info

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,36 @@ Customize and seamlessly integrate advanced language and embedding models into y
   <p><i>Settings Interface</i></p>
 </div>
 
+---
+
+### 📊 Telemetry
+Configure external telemetry settings to monitor and analyze your AI-powered development workflows with environment-specific customization capabilities.
+
+- **External Configuration Override**  
+  - Support for telemetry configuration overrides via a `.hai.config` file placed at the root of your workspace.
+  - Enables environment-specific customization that can be dynamically injected through CI/CD pipelines.
+
+- **Supported Override Parameters**  
+  ```
+  # Langfuse Configuration
+  langfuse.apiUrl=
+  langfuse.apiKey=
+  langfuse.publicKey=
+  
+  # PostHog Configuration
+  posthog.url=
+  posthog.apiKey=
+  ```
+
+**Important Notes:**  
+- The `.hai.config` file is not git-excluded by default. Ensure sensitive keys are not committed unintentionally to your repository.
+
+---
+
+### 📖 Documentation
+For comprehensive documentation and in-depth guides on HAI Code Generator features, visit our [Wiki](https://github.com/presidio-oss/cline-based-code-generator/wiki).
+
+
 ## 🤝 Contributing
 
 To contribute to the project, start by exploring [open issues](https://github.com/presidio-oss/cline-based-code-generator/issues) or checking our [feature request board](https://github.com/presidio-oss/cline-based-code-generator/discussions/categories/feature-requests?discussions_q=is%3Aopen+category%3A%22Feature+Requests%22+sort%3Atop).


### PR DESCRIPTION
### Description

Updated the README to include a Telemetry and Documentation section, detailing how to configure a custom Langfuse and PostHog setup, along with comprehensive documentation for the HAI Code Generator.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)
