### PR TITLE
feat: Apply guardrail on ApiConversationHistory to block or redact the content when anamolly detected

### DIFF
--- a/.changeset/kind-panthers-own.md
+++ b/.changeset/kind-panthers-own.md
@@ -1,0 +1,5 @@
+---
+"hai-build-code-generator": minor
+---
+
+Apply guardrails in Api conversation history to sanitize or block the message when anamolly detected

--- a/src/core/storage/state.ts
+++ b/src/core/storage/state.ts
@@ -15,7 +15,7 @@ import { ClineRulesToggles } from "@shared/cline-rules"
 // TAG:HAI
 import { EmbeddingConfiguration, EmbeddingProvider } from "@shared/embeddings"
 import { HaiBuildContextOptions, HaiBuildIndexProgress } from "@shared/customApi"
-import { GuardrailsConfig } from "@/integrations/guardrails"
+import { Default_GuardsConfig, GuardrailsConfig } from "@/integrations/guardrails"
 
 /*
 	Storage
@@ -538,7 +538,7 @@ export async function getAllExtensionState(context: vscode.ExtensionContext, wor
 			ollamaModelId: embeddingOllamaModelId,
 		},
 		expertPrompt,
-		guardrailsConfig: guardrailsConfig,
+		guardrailsConfig: guardrailsConfig ?? Default_GuardsConfig,
 		buildContextOptions: buildContextOptions
 			? {
 					...buildContextOptions,

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -1695,6 +1695,20 @@ export class Task {
 			return
 		}
 
+		this.apiConversationHistory
+			.filter((message) => message.role === "user")
+			.map(async (m) => {
+				if (Array.isArray(m.content)) {
+					m.content.map(async (c) => {
+						if (c.type === "text") {
+							c.text = await this.guardrails.applyPiiAndSecretGuards(c.text)
+						}
+					})
+				} else if (typeof m.content === "string") {
+					m.content = await this.guardrails.applyPiiAndSecretGuards(m.content)
+				}
+			})
+
 		const contextManagementMetadata = await this.contextManager.getNewContextMessagesAndMetadata(
 			this.apiConversationHistory,
 			this.clineMessages,


### PR DESCRIPTION

### Description
ApiConversationHistory has a similar contents like ClineMessages which holds some of the PII and secret which is visible while combining them. we need to sanitise them as well.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)
