### PR TITLE
AWS Profile Support for Embedding Configuration

### DIFF
--- a/.changeset/six-cameras-begin.md
+++ b/.changeset/six-cameras-begin.md
@@ -1,0 +1,5 @@
+---
+"hai-build-code-generator": minor
+---
+
+Add profile support for Bedrock embeddings configuration

--- a/src/core/storage/state-keys.ts
+++ b/src/core/storage/state-keys.ts
@@ -111,5 +111,7 @@ export type GlobalStateKey =
 	| "embeddingOpenAiBaseUrl"
 	| "embeddingOpenAiModelId"
 	| "guardrailsConfig"
+	| "embeddingAwsUseProfile"
+	| "embeddingAwsProfile"
 
 export type LocalStateKey = "localClineRulesToggles"

--- a/src/core/storage/state.ts
+++ b/src/core/storage/state.ts
@@ -284,6 +284,8 @@ export async function getAllExtensionState(context: vscode.ExtensionContext, wor
 		embeddingOllamaModelId,
 		//Guardrails
 		guardrailsConfig,
+		embeddingAwsUseProfile,
+		embeddingAwsProfile,
 	] = await Promise.all([
 		customGetState(context, "isNewUser") as Promise<boolean | undefined>,
 		customGetState(context, "apiProvider") as Promise<ApiProvider | undefined>,
@@ -401,6 +403,8 @@ export async function getAllExtensionState(context: vscode.ExtensionContext, wor
 		customGetState(context, "embeddingOllamaBaseUrl") as Promise<string | undefined>,
 		customGetState(context, "embeddingOllamaModelId") as Promise<string | undefined>,
 		customGetState(context, "guardrailsConfig") as Promise<GuardrailsConfig | undefined>,
+		customGetState(context, "embeddingAwsUseProfile") as Promise<boolean | undefined>,
+		customGetState(context, "embeddingAwsProfile") as Promise<string | undefined>,
 		fetch,
 	])
 
@@ -540,6 +544,8 @@ export async function getAllExtensionState(context: vscode.ExtensionContext, wor
 			isEmbeddingConfigurationValid,
 			ollamaBaseUrl: embeddingOllamaBaseUrl,
 			ollamaModelId: embeddingOllamaModelId,
+			awsUseProfile: embeddingAwsUseProfile,
+			awsProfile: embeddingAwsProfile
 		},
 		expertPrompt,
 		expertName,
@@ -547,16 +553,16 @@ export async function getAllExtensionState(context: vscode.ExtensionContext, wor
 		guardrailsConfig: guardrailsConfig ?? Default_GuardsConfig,
 		buildContextOptions: buildContextOptions
 			? {
-					...buildContextOptions,
-					systemPromptVersion: buildContextOptions.systemPromptVersion ?? "v3",
-				}
+				...buildContextOptions,
+				systemPromptVersion: buildContextOptions.systemPromptVersion ?? "v3",
+			}
 			: {
-					useIndex: true, // Enable Indexing by default
-					useContext: true, // Enable Use Context by default
-					useSyncWithApi: true, // Enable Sync with API by default
-					useSecretScanning: true, // Enable Secret Scanning by default
-					systemPromptVersion: "v3", // Setting v3 as default prompt
-				},
+				useIndex: true, // Enable Indexing by default
+				useContext: true, // Enable Use Context by default
+				useSyncWithApi: true, // Enable Sync with API by default
+				useSecretScanning: true, // Enable Secret Scanning by default
+				systemPromptVersion: "v3", // Setting v3 as default prompt
+			},
 		buildIndexProgress: buildIndexProgress,
 		enableInlineEdit: enableInlineEdit ?? true,
 		autoApprovalSettings: autoApprovalSettings || DEFAULT_AUTO_APPROVAL_SETTINGS, // default value can be 0 or empty string
@@ -737,6 +743,8 @@ export async function updateEmbeddingConfiguration(
 		azureOpenAIApiVersion,
 		ollamaBaseUrl,
 		ollamaModelId,
+		awsProfile,
+		awsUseProfile
 	} = embeddingConfiguration
 
 	// Update Global State
@@ -750,6 +758,8 @@ export async function updateEmbeddingConfiguration(
 	await customUpdateState(context, "embeddingAzureOpenAIApiEmbeddingsDeploymentName", azureOpenAIApiEmbeddingsDeploymentName)
 	await customUpdateState(context, "embeddingOllamaBaseUrl", ollamaBaseUrl)
 	await customUpdateState(context, "embeddingOllamaModelId", ollamaModelId)
+	await customUpdateState(context, "embeddingAwsProfile", awsProfile)
+	await customUpdateState(context, "embeddingAwsUseProfile", awsUseProfile)
 	// Update Secrets
 	await customStoreSecret(context, "embeddingAwsAccessKey", workspaceId, awsAccessKey, true)
 	await customStoreSecret(context, "embeddingAwsSecretKey", workspaceId, awsSecretKey, true)

--- a/src/embedding/providers/bedrock.ts
+++ b/src/embedding/providers/bedrock.ts
@@ -1,33 +1,48 @@
 import { EmbeddingHandler } from "../"
 import { BedrockEmbeddings } from "@langchain/aws"
 import { EmbeddingHandlerOptions } from "../../shared/embeddings"
+import { BedrockRuntimeClient } from "@aws-sdk/client-bedrock-runtime";
 
 export class AwsBedrockEmbeddingHandler implements EmbeddingHandler {
 	private options: EmbeddingHandlerOptions
-	private client: BedrockEmbeddings
+	private client: BedrockEmbeddings | null = null
 
 	constructor(options: EmbeddingHandlerOptions) {
 		this.options = options
 
+		let bedrockRuntimeClient: BedrockRuntimeClient;
+
+		if (this.options.awsUseProfile) {
+			bedrockRuntimeClient = new BedrockRuntimeClient({
+				region: this.options.awsRegion,
+				profile: this.options.awsProfile,
+			})
+		} else {
+			bedrockRuntimeClient = new BedrockRuntimeClient({
+				region: this.options.awsRegion,
+				credentials: {
+					accessKeyId: this.options.awsAccessKey!,
+					secretAccessKey: this.options.awsSecretKey!,
+					...(this.options.awsSessionToken ? { sessionToken: this.options.awsSessionToken } : {}),
+				},
+			})
+		}
+
 		this.client = new BedrockEmbeddings({
-			model: this.options.modelId,
-			region: this.options.awsRegion,
-			credentials: {
-				accessKeyId: this.options.awsAccessKey!,
-				secretAccessKey: this.options.awsSecretKey!,
-				...(this.options.awsSessionToken ? { sessionToken: this.options.awsSessionToken } : {}),
-			},
-			maxRetries: this.options.maxRetries,
+			client: bedrockRuntimeClient, onFailedAttempt: (error) => {
+				console.error("Failed attempt in Bedrock Embeddings:", error);
+				throw error;
+			}
 		})
 	}
 
 	getClient() {
-		return this.client
+		return this.client!;
 	}
 
 	async validateAPIKey(): Promise<boolean> {
 		try {
-			await this.client.embedQuery("Test")
+			await this.client!.embedQuery("Test")
 			return true
 		} catch (error) {
 			console.error("Error validating Bedrock embedding credentials: ", error)

--- a/src/shared/embeddings.ts
+++ b/src/shared/embeddings.ts
@@ -19,6 +19,8 @@ export interface EmbeddingHandlerOptions {
 	maxRetries?: number
 	ollamaBaseUrl?: string
 	ollamaModelId?: string
+	awsProfile?: string
+	awsUseProfile?: boolean
 }
 
 export type EmbeddingConfiguration = EmbeddingHandlerOptions & {

--- a/src/shared/validate.ts
+++ b/src/shared/validate.ts
@@ -128,8 +128,14 @@ export function validateEmbeddingConfiguration(config?: EmbeddingConfiguration):
 				}
 				break
 			case "bedrock":
-				if (!config.awsRegion || !config.awsAccessKey || !config.awsSecretKey) {
-					return "You must provide a valid Access Key, Secret Key and Region to use AWS Bedrock."
+				if (config.awsUseProfile) {
+					if (!config.awsRegion) {
+						return "You must provide a valid Region to use AWS Bedrock with profile."
+					}
+				} else {
+					if (!config.awsRegion || !config.awsAccessKey || !config.awsSecretKey) {
+						return "You must provide a valid Access Key, Secret Key and Region to use AWS Bedrock."
+					}
 				}
 				break
 			case "openai":


### PR DESCRIPTION

### Description

This PR adds AWS profile authentication support for embedding options, allowing users to use their AWS profiles instead of directly entering AWS credentials. This feature was requested in issue #147.


Key changes:
- Added radio button selection between AWS credentials and AWS profile authentication methods in embeddings congfiguration
- Implemented profile name input field when profile authentication is selected


### Type of Change


-   [ x ] ✨ New feature (non-breaking change which adds functionality)


### Pre-flight Checklist


-   [ x ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ x ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ x ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ x ] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)

### Screenshots

<img width="611" alt="Screenshot 2025-06-13 at 10 26 40 PM" src="https://github.com/user-attachments/assets/21f5aa5f-2195-45cc-974d-d5ec1f98eab1" />


### Additional Notes

<!-- Add any additional notes for reviewers -->