### PR TITLE
fix: LLM validation hangs on welcome state

### DIFF
--- a/.changeset/three-numbers-cough.md
+++ b/.changeset/three-numbers-cough.md
@@ -1,0 +1,5 @@
+---
+"hai-build-code-generator": patch
+---
+
+Resolved an issue where LLM validation could become stuck in the welcome state, preventing further progress.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: "Release"
 on:
     push:
         branches:
-            - release
+            - main
     workflow_dispatch:
 
 permissions:

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -158,10 +158,27 @@ export class Controller {
 	// TAG:HAI
 	private async getExpertManager(): Promise<ExpertManager> {
 		if (!this.expertManager) {
-			const { embeddingConfiguration } = await getAllExtensionState(this.context, this.workspaceId)
-			this.expertManager = new ExpertManager(this.context, this.workspaceId, embeddingConfiguration)
+			this.expertManager = new ExpertManager(this.context, this.workspaceId)
 		}
 		return this.expertManager
+	}
+
+	/**
+	 * Initialize embeddings in ExpertManager
+	 */
+	public async initializeExpertManagerEmbeddings(): Promise<void> {
+		if (!this.expertManager) {
+			this.expertManager = new ExpertManager(this.context, this.workspaceId)
+		}
+		const { embeddingConfiguration } = await getAllExtensionState(this.context, this.workspaceId)
+		const embeddingHandler = buildEmbeddingHandler({
+			...embeddingConfiguration,
+			maxRetries: 0,
+		})
+		const isEmbeddingValid = await embeddingHandler.validateAPIKey()
+		if (isEmbeddingValid) {
+			this.expertManager.initializeEmbeddings(embeddingConfiguration)
+		}
 	}
 
 	/*

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -4646,7 +4646,8 @@ export class Task {
 						this.consecutiveMistakeCount = 0
 
 						// Create ExpertManager instance and search for the query
-						const expertManager = new ExpertManager(this.context, this.taskId, this.embeddingConfiguration)
+						const expertManager = new ExpertManager(this.context, this.taskId)
+						expertManager.initializeEmbeddings(this.embeddingConfiguration)
 						const searchResults = await expertManager.search(query, expertName, cwd)
 
 						// Format the complete message with search results

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -217,6 +217,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			WebviewProvider.getAllInstances().forEach((instance) => {
 				const openExperts = async (instance?: WebviewProvider) => {
 					await instance?.controller.postStateToWebview()
+					instance?.controller.initializeExpertManagerEmbeddings()
 					instance?.controller.postMessageToWebview({
 						type: "action",
 						action: "expertsButtonClicked",

--- a/webview-ui/src/components/experts/ExpertsView.tsx
+++ b/webview-ui/src/components/experts/ExpertsView.tsx
@@ -759,9 +759,10 @@ const ExpertsView: React.FC<ExpertsViewProps> = ({ onDone }) => {
 												}}
 											/>
 											<span>
-												Important: Experts created with specific embedding configurations must use the
-												same embedding settings. Using different embeddings will prevent the experts from
-												working.
+												Important: If you change the embedding configuration, any experts with DeepCrawl
+												enabled must be deleted and recreated using the updated settings. Experts rely on
+												a consistent embedding setup — using different configurations can prevent them
+												from functioning properly.
 											</span>
 										</div>
 									)}

--- a/webview-ui/src/components/experts/ExpertsView.tsx
+++ b/webview-ui/src/components/experts/ExpertsView.tsx
@@ -735,6 +735,36 @@ const ExpertsView: React.FC<ExpertsViewProps> = ({ onDone }) => {
 										/>
 										<p className="description-text">Sets the crawl timeout for each page.</p>
 									</FormGroup>
+									{deepCrawl && (
+										<div
+											className="info-message"
+											style={{
+												display: "flex",
+												alignItems: "flex-start",
+												gap: "8px",
+												color: "var(--vscode-foreground)",
+												fontSize: "12px",
+												padding: "8px",
+												backgroundColor: "var(--vscode-editorWidget-background)",
+												border: "1px solid var(--vscode-widget-border)",
+												borderRadius: "4px",
+												marginBottom: "16px",
+											}}>
+											<i
+												className="codicon codicon-info"
+												style={{
+													fontSize: "14px",
+													marginTop: "2px",
+													color: "var(--vscode-textLink-foreground)",
+												}}
+											/>
+											<span>
+												Important: Experts created with specific embedding configurations must use the
+												same embedding settings. Using different embeddings will prevent the experts from
+												working.
+											</span>
+										</div>
+									)}
 								</>
 							)}
 							{!isEmbeddingValid && (


### PR DESCRIPTION
### Description

- Resolved an issue where LLM validation could become stuck in the welcome state, preventing further progress.
- Added information to guide users on embedding configuration when Deepcrawl is enabled.


### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)
