### PR TITLE
fix: Standardize naming from CorMatrix to COR-Matrix in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 - [📝 HAI Tasks](#-hai-tasks) : Integrate AI-generated user stories and tasks seamlessly into your workflow  
 - [🔍 File Identification](#-file-identification) : Discover and contextualize code files with intelligent indexing  
 - [⚙️ Settings Interface](#-settings-interface) : Easily configure LLMs and embedding models for tailored performance
-- [📊 CorMatrix Integration](#-cormatrix-integration) : Track AI code retention patterns and analyze code origin over time
+- [📊 COR-Matrix Integration](#-cormatrix-integration) : Track AI code retention patterns and analyze code origin over time
 
 <br>
 
@@ -171,7 +171,7 @@ Customize and seamlessly integrate advanced language and embedding models into y
 
 ---
 
-### 📊 CorMatrix Integration
+### 📊 COR-Matrix Integration
 Track AI code retention patterns and analyze how much AI-generated code remains in your codebase over time.
 
 - **Code Origin Tracking**: Monitor AI-generated code longevity and evolution patterns
@@ -179,7 +179,7 @@ Track AI code retention patterns and analyze how much AI-generated code remains 
 - **Optional Integration**: Activate through workspace configuration when needed
 - **Zero Performance Impact**: Background processing with graceful degradation
 
-For detailed setup and configuration, see our [CorMatrix Integration Guide](docs/features/cormatrix-integration.md).
+For detailed setup and configuration, see our [COR-Matrix Integration Guide](docs/features/cormatrix-integration.md).
 
 ---
 

--- a/docs/features/cormatrix-integration.md
+++ b/docs/features/cormatrix-integration.md
@@ -1,10 +1,10 @@
-# CorMatrix Integration
+# COR-Matrix Integration
 
-The HAI Code Generator includes built-in integration with CorMatrix, a Code Origin Ratio tracking system that helps you understand how much AI-generated code is retained over time.
+The HAI Code Generator includes built-in integration with COR-Matrix, a Code Origin Ratio tracking system that helps you understand how much AI-generated code is retained over time.
 
-## What is CorMatrix?
+## What is COR-Matrix?
 
-CorMatrix is a Node.js SDK and CLI that analyzes AI code retention patterns by tracking how much AI-generated code remains in your codebase versus how much gets modified or removed over time. The HAI Code Generator automatically tracks file operations performed by the AI assistant and sends this data to CorMatrix for analysis.
+COR-Matrix is a Node.js SDK and CLI that analyzes AI code retention patterns by tracking how much AI-generated code remains in your codebase versus how much gets modified or removed over time. The HAI Code Generator automatically tracks file operations performed by the AI assistant and sends this data to COR-Matrix for analysis.
 
 This provides valuable insights into:
 
@@ -13,7 +13,7 @@ This provides valuable insights into:
 - **Retention Rates**: What percentage of AI-generated code survives in the final codebase
 - **Usage Patterns**: Understanding the real-world effectiveness of AI coding assistance
 
-For detailed information about CorMatrix SDK and CLI, see the [official documentation](https://www.npmjs.com/package/@presidio-dev/cor-matrix).
+For detailed information about COR-Matrix SDK and CLI, see the [official documentation](https://www.npmjs.com/package/@presidio-dev/cor-matrix).
 
 ## How It Works
 
@@ -21,31 +21,31 @@ The HAI Code Generator conditionally tracks file operations through the `CorMatr
 
 1. The AI assistant performs a file modification or creation
 2. The operation contains valid file content with line-level changes
-3. Required CorMatrix configuration is present in your workspace
-4. The CorMatrix service is available and properly configured
+3. Required COR-Matrix configuration is present in your workspace
+4. The COR-Matrix service is available and properly configured
 
-> **Important Note**: Your actual source code **never leaves your system**. Only cryptographic hash signatures are generated locally and sent to CorMatrix for analysis. All data is encrypted in transit and at rest. Tracking runs in the background with batch processing, ensuring **zero impact** on AI assistant performance.
+> **Important Note**: Your actual source code **never leaves your system**. Only cryptographic hash signatures are generated locally and sent to COR-Matrix for analysis. All data is encrypted in transit and at rest. Tracking runs in the background with batch processing, ensuring **zero impact** on AI assistant performance.
 
 ## Privacy & Security
 
-CorMatrix integration is designed with privacy and security in mind:
+COR-Matrix integration is designed with privacy and security in mind:
 
 - **Your Code Stays Local**: Your actual source code **never leaves your development environment**
-- **Hash-Only Transmission**: Only cryptographic hash signatures are generated locally and sent to CorMatrix
+- **Hash-Only Transmission**: Only cryptographic hash signatures are generated locally and sent to COR-Matrix
 - **Encryption**: All transmitted data is encrypted in transit and at rest
 - **Selective Tracking**: Only AI-generated code additions are monitored (deletions are ignored)
 - **Background Processing**: Tracking uses batching and background processing for zero performance impact
 
 ## Configuration
 
-CorMatrix integration is **completely optional** and activates only when configured.
+COR-Matrix integration is **completely optional** and activates only when configured.
 
 ### Workspace Configuration
 
-Create a `.hai.config` file in your workspace root with the following CorMatrix settings:
+Create a `.hai.config` file in your workspace root with the following COR-Matrix settings:
 
 ```
-# CorMatrix Configuration
+# COR-Matrix Configuration
 cormatrix.baseURL=https://your-cormatrix-instance.com
 cormatrix.token=your-api-token
 cormatrix.workspaceId=your-workspace-id
@@ -53,8 +53,8 @@ cormatrix.workspaceId=your-workspace-id
 
 ### Configuration Parameters
 
-- **`baseURL`**: Your CorMatrix server endpoint
-- **`token`**: Authentication token for CorMatrix API
+- **`baseURL`**: Your COR-Matrix server endpoint
+- **`token`**: Authentication token for COR-Matrix API
 - **`workspaceId`**: Unique identifier for your workspace
 
 All parameters are optional, but the integration will only activate when all required parameters are provided.
@@ -65,11 +65,11 @@ All parameters are optional, but the integration will only activate when all req
 
 ## Optional Integration
 
-CorMatrix integration provides graceful operation:
+COR-Matrix integration provides graceful operation:
 
-- **Default Behavior**: HAI Code Generator operates normally without CorMatrix configuration
+- **Default Behavior**: HAI Code Generator operates normally without COR-Matrix configuration
 - **Silent Activation**: Integration only activates when required configuration is present
-- **Graceful Degradation**: If CorMatrix service is unavailable, the AI assistant continues working unaffected
+- **Graceful Degradation**: If COR-Matrix service is unavailable, the AI assistant continues working unaffected
 - **Zero Performance Impact**: All tracking happens in the background without affecting your development workflow
 
 ## How Tracking Works
@@ -80,23 +80,23 @@ The integration automatically:
 2. **Captures Line Diffs**: Records line-by-line changes made by the AI
 3. **Processes Added Code**: Only tracks newly added code (deletions are ignored)
 4. **Generates Hashes**: Creates cryptographic signatures of the added code locally
-5. **Transmits Safely**: Sends only hash signatures and metadata to CorMatrix
+5. **Transmits Safely**: Sends only hash signatures and metadata to COR-Matrix
 6. **Associates with Files**: Links generated code signatures to specific file paths
 
 ## Troubleshooting
 
 ### Integration Not Working
 
-If CorMatrix integration isn't tracking changes:
+If COR-Matrix integration isn't tracking changes:
 
 1. **Check Configuration**: Ensure all required parameters are set in `.hai.config`
-2. **Verify Connectivity**: Test connection to your CorMatrix instance
-3. **Review Logs**: Check HAI Code Generator logs for CorMatrix-related errors
+2. **Verify Connectivity**: Test connection to your COR-Matrix instance
+3. **Review Logs**: Check HAI Code Generator logs for COR-Matrix-related errors
 4. **Validate Credentials**: Confirm your token and workspace ID are correct
 
 ### Performance Concerns
 
-CorMatrix integration is designed for zero performance impact:
+COR-Matrix integration is designed for zero performance impact:
 
 - All processing happens in background threads
 - Batch processing minimizes network requests
@@ -105,11 +105,11 @@ CorMatrix integration is designed for zero performance impact:
 
 ### Privacy Questions
 
-**Q: What data is sent to CorMatrix?**
+**Q: What data is sent to COR-Matrix?**
 A: Only cryptographic hash signatures of added code and associated file paths. Your actual source code never leaves your system.
 
-**Q: Can CorMatrix reconstruct my code from hashes?**
+**Q: Can COR-Matrix reconstruct my code from hashes?**
 A: No. Cryptographic hashes are one-way functions that cannot be reversed to reveal the original code.
 
 **Q: Is tracking mandatory?**
-A: No. CorMatrix integration is completely optional and only activates when explicitly configured.
+A: No. COR-Matrix integration is completely optional and only activates when explicitly configured.


### PR DESCRIPTION
Updated all instances of "CorMatrix" to "COR-Matrix" in README and integration guide for consistency and clarity. This change enhances the accuracy of references to the integration feature.

### Description

<!-- Describe your changes in detail. What problem does this PR solve? -->

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [ ] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->
