### PR TITLE
fix: langfuse trace not found 

### DIFF
--- a/.changeset/real-items-occur.md
+++ b/.changeset/real-items-occur.md
@@ -1,0 +1,5 @@
+---
+"hai-build-code-generator": patch
+---
+
+Resolved the langfuse trace not found issue by updating the esbuild.js configuration to include the langfuse environment variables during the build process. This ensures that langfuse traces are correctly initialized at runtime by making the API and public keys available in the client bundle.

--- a/esbuild.js
+++ b/esbuild.js
@@ -146,6 +146,11 @@ const extensionConfig = {
 	entryPoints: ["src/extension.ts"],
 	outfile: `${destDir}/extension.js`,
 	external: ["vscode", "faiss-node"],
+	define: {
+		"process.env.LANGFUSE_API_KEY": JSON.stringify(process.env.LANGFUSE_API_KEY || ""),
+		"process.env.LANGFUSE_PUBLIC_KEY": JSON.stringify(process.env.LANGFUSE_PUBLIC_KEY || ""),
+		"process.env.LANGFUSE_API_URL": JSON.stringify(process.env.LANGFUSE_API_URL || "https://us.cloud.langfuse.com"),
+	},
 }
 
 // Standalone-specific configuration

--- a/esbuild.js
+++ b/esbuild.js
@@ -127,6 +127,9 @@ const baseConfig = {
 	logLevel: "silent",
 	define: {
 		"process.env.IS_DEV": JSON.stringify(!production),
+		"process.env.LANGFUSE_API_KEY": JSON.stringify(process.env.LANGFUSE_API_KEY || ""),
+		"process.env.LANGFUSE_PUBLIC_KEY": JSON.stringify(process.env.LANGFUSE_PUBLIC_KEY || ""),
+		"process.env.LANGFUSE_API_URL": JSON.stringify(process.env.LANGFUSE_API_URL || "https://us.cloud.langfuse.com"),
 	},
 	tsconfig: path.resolve(__dirname, "tsconfig.json"),
 	plugins: [
@@ -146,11 +149,6 @@ const extensionConfig = {
 	entryPoints: ["src/extension.ts"],
 	outfile: `${destDir}/extension.js`,
 	external: ["vscode", "faiss-node"],
-	define: {
-		"process.env.LANGFUSE_API_KEY": JSON.stringify(process.env.LANGFUSE_API_KEY || ""),
-		"process.env.LANGFUSE_PUBLIC_KEY": JSON.stringify(process.env.LANGFUSE_PUBLIC_KEY || ""),
-		"process.env.LANGFUSE_API_URL": JSON.stringify(process.env.LANGFUSE_API_URL || "https://us.cloud.langfuse.com"),
-	},
 }
 
 // Standalone-specific configuration


### PR DESCRIPTION


### Description

- Resolved the langfuse trace not found issue by configuring environment variables in esbuild.js to include the langfuse keys during the build process.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)
