### PR TITLE
feat: Enhance Claude Sonnet 4 support with 1M context window and tiered pricing

### DIFF
--- a/.changeset/fair-buttons-chew.md
+++ b/.changeset/fair-buttons-chew.md
@@ -1,0 +1,5 @@
+---
+"hai-build-code-generator": patch
+---
+
+Enhanced support for Claude Sonnet 4, extending its maximum context window to 1 million tokens and enabling tiered pricing for more flexible usage models.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@anthropic-ai/bedrock-sdk": "^0.12.4",
 				"@anthropic-ai/sdk": "^0.37.0",
 				"@anthropic-ai/vertex-sdk": "^0.6.4",
-				"@aws-sdk/client-bedrock-runtime": "^3.758.0",
+				"@aws-sdk/client-bedrock-runtime": "^3.873.0",
 				"@bufbuild/protobuf": "^2.2.5",
 				"@google-cloud/vertexai": "^1.9.3",
 				"@google/genai": "^0.13.0",
@@ -1549,52 +1549,56 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime": {
-			"version": "3.758.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.758.0.tgz",
-			"integrity": "sha512-T7s+fULUxN3AcJP+lgoUKLawzVEtyCTi+5Ga+wrHnqEPwAsM/wg7VctsZfow1fCgARLT/lzmP2LTCi8ycRnQWg==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.873.0.tgz",
+			"integrity": "sha512-g2nTwBLudYtugLuFcnJWwPNU9wPvrt1PaMthsBL8KXG7Q3DPRjK2n3jq7JO12U5Zr0oYNzXju2gRybrVrma9zA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.758.0",
-				"@aws-sdk/credential-provider-node": "3.758.0",
-				"@aws-sdk/middleware-host-header": "3.734.0",
-				"@aws-sdk/middleware-logger": "3.734.0",
-				"@aws-sdk/middleware-recursion-detection": "3.734.0",
-				"@aws-sdk/middleware-user-agent": "3.758.0",
-				"@aws-sdk/region-config-resolver": "3.734.0",
-				"@aws-sdk/types": "3.734.0",
-				"@aws-sdk/util-endpoints": "3.743.0",
-				"@aws-sdk/util-user-agent-browser": "3.734.0",
-				"@aws-sdk/util-user-agent-node": "3.758.0",
-				"@smithy/config-resolver": "^4.0.1",
-				"@smithy/core": "^3.1.5",
-				"@smithy/eventstream-serde-browser": "^4.0.1",
-				"@smithy/eventstream-serde-config-resolver": "^4.0.1",
-				"@smithy/eventstream-serde-node": "^4.0.1",
-				"@smithy/fetch-http-handler": "^5.0.1",
-				"@smithy/hash-node": "^4.0.1",
-				"@smithy/invalid-dependency": "^4.0.1",
-				"@smithy/middleware-content-length": "^4.0.1",
-				"@smithy/middleware-endpoint": "^4.0.6",
-				"@smithy/middleware-retry": "^4.0.7",
-				"@smithy/middleware-serde": "^4.0.2",
-				"@smithy/middleware-stack": "^4.0.1",
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/node-http-handler": "^4.0.3",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/smithy-client": "^4.1.6",
-				"@smithy/types": "^4.1.0",
-				"@smithy/url-parser": "^4.0.1",
+				"@aws-sdk/core": "3.873.0",
+				"@aws-sdk/credential-provider-node": "3.873.0",
+				"@aws-sdk/eventstream-handler-node": "3.873.0",
+				"@aws-sdk/middleware-eventstream": "3.873.0",
+				"@aws-sdk/middleware-host-header": "3.873.0",
+				"@aws-sdk/middleware-logger": "3.873.0",
+				"@aws-sdk/middleware-recursion-detection": "3.873.0",
+				"@aws-sdk/middleware-user-agent": "3.873.0",
+				"@aws-sdk/middleware-websocket": "3.873.0",
+				"@aws-sdk/region-config-resolver": "3.873.0",
+				"@aws-sdk/token-providers": "3.873.0",
+				"@aws-sdk/types": "3.862.0",
+				"@aws-sdk/util-endpoints": "3.873.0",
+				"@aws-sdk/util-user-agent-browser": "3.873.0",
+				"@aws-sdk/util-user-agent-node": "3.873.0",
+				"@smithy/config-resolver": "^4.1.5",
+				"@smithy/core": "^3.8.0",
+				"@smithy/eventstream-serde-browser": "^4.0.5",
+				"@smithy/eventstream-serde-config-resolver": "^4.1.3",
+				"@smithy/eventstream-serde-node": "^4.0.5",
+				"@smithy/fetch-http-handler": "^5.1.1",
+				"@smithy/hash-node": "^4.0.5",
+				"@smithy/invalid-dependency": "^4.0.5",
+				"@smithy/middleware-content-length": "^4.0.5",
+				"@smithy/middleware-endpoint": "^4.1.18",
+				"@smithy/middleware-retry": "^4.1.19",
+				"@smithy/middleware-serde": "^4.0.9",
+				"@smithy/middleware-stack": "^4.0.5",
+				"@smithy/node-config-provider": "^4.1.4",
+				"@smithy/node-http-handler": "^4.1.1",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/smithy-client": "^4.4.10",
+				"@smithy/types": "^4.3.2",
+				"@smithy/url-parser": "^4.0.5",
 				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-body-length-browser": "^4.0.0",
 				"@smithy/util-body-length-node": "^4.0.0",
-				"@smithy/util-defaults-mode-browser": "^4.0.7",
-				"@smithy/util-defaults-mode-node": "^4.0.7",
-				"@smithy/util-endpoints": "^3.0.1",
-				"@smithy/util-middleware": "^4.0.1",
-				"@smithy/util-retry": "^4.0.1",
-				"@smithy/util-stream": "^4.1.2",
+				"@smithy/util-defaults-mode-browser": "^4.0.26",
+				"@smithy/util-defaults-mode-node": "^4.0.26",
+				"@smithy/util-endpoints": "^3.0.7",
+				"@smithy/util-middleware": "^4.0.5",
+				"@smithy/util-retry": "^4.0.7",
+				"@smithy/util-stream": "^4.2.4",
 				"@smithy/util-utf8": "^4.0.0",
 				"@types/uuid": "^9.0.1",
 				"tslib": "^2.6.2",
@@ -1605,47 +1609,47 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/client-sso": {
-			"version": "3.758.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.758.0.tgz",
-			"integrity": "sha512-BoGO6IIWrLyLxQG6txJw6RT2urmbtlwfggapNCrNPyYjlXpzTSJhBYjndg7TpDATFd0SXL0zm8y/tXsUXNkdYQ==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.873.0.tgz",
+			"integrity": "sha512-EmcrOgFODWe7IsLKFTeSXM9TlQ80/BO1MBISlr7w2ydnOaUYIiPGRRJnDpeIgMaNqT4Rr2cRN2RiMrbFO7gDdA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.758.0",
-				"@aws-sdk/middleware-host-header": "3.734.0",
-				"@aws-sdk/middleware-logger": "3.734.0",
-				"@aws-sdk/middleware-recursion-detection": "3.734.0",
-				"@aws-sdk/middleware-user-agent": "3.758.0",
-				"@aws-sdk/region-config-resolver": "3.734.0",
-				"@aws-sdk/types": "3.734.0",
-				"@aws-sdk/util-endpoints": "3.743.0",
-				"@aws-sdk/util-user-agent-browser": "3.734.0",
-				"@aws-sdk/util-user-agent-node": "3.758.0",
-				"@smithy/config-resolver": "^4.0.1",
-				"@smithy/core": "^3.1.5",
-				"@smithy/fetch-http-handler": "^5.0.1",
-				"@smithy/hash-node": "^4.0.1",
-				"@smithy/invalid-dependency": "^4.0.1",
-				"@smithy/middleware-content-length": "^4.0.1",
-				"@smithy/middleware-endpoint": "^4.0.6",
-				"@smithy/middleware-retry": "^4.0.7",
-				"@smithy/middleware-serde": "^4.0.2",
-				"@smithy/middleware-stack": "^4.0.1",
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/node-http-handler": "^4.0.3",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/smithy-client": "^4.1.6",
-				"@smithy/types": "^4.1.0",
-				"@smithy/url-parser": "^4.0.1",
+				"@aws-sdk/core": "3.873.0",
+				"@aws-sdk/middleware-host-header": "3.873.0",
+				"@aws-sdk/middleware-logger": "3.873.0",
+				"@aws-sdk/middleware-recursion-detection": "3.873.0",
+				"@aws-sdk/middleware-user-agent": "3.873.0",
+				"@aws-sdk/region-config-resolver": "3.873.0",
+				"@aws-sdk/types": "3.862.0",
+				"@aws-sdk/util-endpoints": "3.873.0",
+				"@aws-sdk/util-user-agent-browser": "3.873.0",
+				"@aws-sdk/util-user-agent-node": "3.873.0",
+				"@smithy/config-resolver": "^4.1.5",
+				"@smithy/core": "^3.8.0",
+				"@smithy/fetch-http-handler": "^5.1.1",
+				"@smithy/hash-node": "^4.0.5",
+				"@smithy/invalid-dependency": "^4.0.5",
+				"@smithy/middleware-content-length": "^4.0.5",
+				"@smithy/middleware-endpoint": "^4.1.18",
+				"@smithy/middleware-retry": "^4.1.19",
+				"@smithy/middleware-serde": "^4.0.9",
+				"@smithy/middleware-stack": "^4.0.5",
+				"@smithy/node-config-provider": "^4.1.4",
+				"@smithy/node-http-handler": "^4.1.1",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/smithy-client": "^4.4.10",
+				"@smithy/types": "^4.3.2",
+				"@smithy/url-parser": "^4.0.5",
 				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-body-length-browser": "^4.0.0",
 				"@smithy/util-body-length-node": "^4.0.0",
-				"@smithy/util-defaults-mode-browser": "^4.0.7",
-				"@smithy/util-defaults-mode-node": "^4.0.7",
-				"@smithy/util-endpoints": "^3.0.1",
-				"@smithy/util-middleware": "^4.0.1",
-				"@smithy/util-retry": "^4.0.1",
+				"@smithy/util-defaults-mode-browser": "^4.0.26",
+				"@smithy/util-defaults-mode-node": "^4.0.26",
+				"@smithy/util-endpoints": "^3.0.7",
+				"@smithy/util-middleware": "^4.0.5",
+				"@smithy/util-retry": "^4.0.7",
 				"@smithy/util-utf8": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -1654,21 +1658,25 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/core": {
-			"version": "3.758.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.758.0.tgz",
-			"integrity": "sha512-0RswbdR9jt/XKemaLNuxi2gGr4xGlHyGxkTdhSQzCyUe9A9OPCoLl3rIESRguQEech+oJnbHk/wuiwHqTuP9sg==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.873.0.tgz",
+			"integrity": "sha512-WrROjp8X1VvmnZ4TBzwM7RF+EB3wRaY9kQJLXw+Aes0/3zRjUXvGIlseobGJMqMEGnM0YekD2F87UaVfot1xeQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.734.0",
-				"@smithy/core": "^3.1.5",
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/property-provider": "^4.0.1",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/signature-v4": "^5.0.1",
-				"@smithy/smithy-client": "^4.1.6",
-				"@smithy/types": "^4.1.0",
-				"@smithy/util-middleware": "^4.0.1",
-				"fast-xml-parser": "4.4.1",
+				"@aws-sdk/types": "3.862.0",
+				"@aws-sdk/xml-builder": "3.873.0",
+				"@smithy/core": "^3.8.0",
+				"@smithy/node-config-provider": "^4.1.4",
+				"@smithy/property-provider": "^4.0.5",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/signature-v4": "^5.1.3",
+				"@smithy/smithy-client": "^4.4.10",
+				"@smithy/types": "^4.3.2",
+				"@smithy/util-base64": "^4.0.0",
+				"@smithy/util-body-length-browser": "^4.0.0",
+				"@smithy/util-middleware": "^4.0.5",
+				"@smithy/util-utf8": "^4.0.0",
+				"fast-xml-parser": "5.2.5",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1676,15 +1684,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.758.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.758.0.tgz",
-			"integrity": "sha512-N27eFoRrO6MeUNumtNHDW9WOiwfd59LPXPqDrIa3kWL/s+fOKFHb9xIcF++bAwtcZnAxKkgpDCUP+INNZskE+w==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.873.0.tgz",
+			"integrity": "sha512-FWj1yUs45VjCADv80JlGshAttUHBL2xtTAbJcAxkkJZzLRKVkdyrepFWhv/95MvDyzfbT6PgJiWMdW65l/8ooA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.758.0",
-				"@aws-sdk/types": "3.734.0",
-				"@smithy/property-provider": "^4.0.1",
-				"@smithy/types": "^4.1.0",
+				"@aws-sdk/core": "3.873.0",
+				"@aws-sdk/types": "3.862.0",
+				"@smithy/property-provider": "^4.0.5",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1692,20 +1700,20 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.758.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.758.0.tgz",
-			"integrity": "sha512-Xt9/U8qUCiw1hihztWkNeIR+arg6P+yda10OuCHX6kFVx3auTlU7+hCqs3UxqniGU4dguHuftf3mRpi5/GJ33Q==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.873.0.tgz",
+			"integrity": "sha512-0sIokBlXIsndjZFUfr3Xui8W6kPC4DAeBGAXxGi9qbFZ9PWJjn1vt2COLikKH3q2snchk+AsznREZG8NW6ezSg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.758.0",
-				"@aws-sdk/types": "3.734.0",
-				"@smithy/fetch-http-handler": "^5.0.1",
-				"@smithy/node-http-handler": "^4.0.3",
-				"@smithy/property-provider": "^4.0.1",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/smithy-client": "^4.1.6",
-				"@smithy/types": "^4.1.0",
-				"@smithy/util-stream": "^4.1.2",
+				"@aws-sdk/core": "3.873.0",
+				"@aws-sdk/types": "3.862.0",
+				"@smithy/fetch-http-handler": "^5.1.1",
+				"@smithy/node-http-handler": "^4.1.1",
+				"@smithy/property-provider": "^4.0.5",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/smithy-client": "^4.4.10",
+				"@smithy/types": "^4.3.2",
+				"@smithy/util-stream": "^4.2.4",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1713,23 +1721,23 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.758.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.758.0.tgz",
-			"integrity": "sha512-cymSKMcP5d+OsgetoIZ5QCe1wnp2Q/tq+uIxVdh9MbfdBBEnl9Ecq6dH6VlYS89sp4QKuxHxkWXVnbXU3Q19Aw==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.873.0.tgz",
+			"integrity": "sha512-bQdGqh47Sk0+2S3C+N46aNQsZFzcHs7ndxYLARH/avYXf02Nl68p194eYFaAHJSQ1re5IbExU1+pbums7FJ9fA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.758.0",
-				"@aws-sdk/credential-provider-env": "3.758.0",
-				"@aws-sdk/credential-provider-http": "3.758.0",
-				"@aws-sdk/credential-provider-process": "3.758.0",
-				"@aws-sdk/credential-provider-sso": "3.758.0",
-				"@aws-sdk/credential-provider-web-identity": "3.758.0",
-				"@aws-sdk/nested-clients": "3.758.0",
-				"@aws-sdk/types": "3.734.0",
-				"@smithy/credential-provider-imds": "^4.0.1",
-				"@smithy/property-provider": "^4.0.1",
-				"@smithy/shared-ini-file-loader": "^4.0.1",
-				"@smithy/types": "^4.1.0",
+				"@aws-sdk/core": "3.873.0",
+				"@aws-sdk/credential-provider-env": "3.873.0",
+				"@aws-sdk/credential-provider-http": "3.873.0",
+				"@aws-sdk/credential-provider-process": "3.873.0",
+				"@aws-sdk/credential-provider-sso": "3.873.0",
+				"@aws-sdk/credential-provider-web-identity": "3.873.0",
+				"@aws-sdk/nested-clients": "3.873.0",
+				"@aws-sdk/types": "3.862.0",
+				"@smithy/credential-provider-imds": "^4.0.7",
+				"@smithy/property-provider": "^4.0.5",
+				"@smithy/shared-ini-file-loader": "^4.0.5",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1737,22 +1745,22 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.758.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.758.0.tgz",
-			"integrity": "sha512-+DaMv63wiq7pJrhIQzZYMn4hSarKiizDoJRvyR7WGhnn0oQ/getX9Z0VNCV3i7lIFoLNTb7WMmQ9k7+z/uD5EQ==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.873.0.tgz",
+			"integrity": "sha512-+v/xBEB02k2ExnSDL8+1gD6UizY4Q/HaIJkNSkitFynRiiTQpVOSkCkA0iWxzksMeN8k1IHTE5gzeWpkEjNwbA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "3.758.0",
-				"@aws-sdk/credential-provider-http": "3.758.0",
-				"@aws-sdk/credential-provider-ini": "3.758.0",
-				"@aws-sdk/credential-provider-process": "3.758.0",
-				"@aws-sdk/credential-provider-sso": "3.758.0",
-				"@aws-sdk/credential-provider-web-identity": "3.758.0",
-				"@aws-sdk/types": "3.734.0",
-				"@smithy/credential-provider-imds": "^4.0.1",
-				"@smithy/property-provider": "^4.0.1",
-				"@smithy/shared-ini-file-loader": "^4.0.1",
-				"@smithy/types": "^4.1.0",
+				"@aws-sdk/credential-provider-env": "3.873.0",
+				"@aws-sdk/credential-provider-http": "3.873.0",
+				"@aws-sdk/credential-provider-ini": "3.873.0",
+				"@aws-sdk/credential-provider-process": "3.873.0",
+				"@aws-sdk/credential-provider-sso": "3.873.0",
+				"@aws-sdk/credential-provider-web-identity": "3.873.0",
+				"@aws-sdk/types": "3.862.0",
+				"@smithy/credential-provider-imds": "^4.0.7",
+				"@smithy/property-provider": "^4.0.5",
+				"@smithy/shared-ini-file-loader": "^4.0.5",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1760,16 +1768,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.758.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.758.0.tgz",
-			"integrity": "sha512-AzcY74QTPqcbXWVgjpPZ3HOmxQZYPROIBz2YINF0OQk0MhezDWV/O7Xec+K1+MPGQO3qS6EDrUUlnPLjsqieHA==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.873.0.tgz",
+			"integrity": "sha512-ycFv9WN+UJF7bK/ElBq1ugWA4NMbYS//1K55bPQZb2XUpAM2TWFlEjG7DIyOhLNTdl6+CbHlCdhlKQuDGgmm0A==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.758.0",
-				"@aws-sdk/types": "3.734.0",
-				"@smithy/property-provider": "^4.0.1",
-				"@smithy/shared-ini-file-loader": "^4.0.1",
-				"@smithy/types": "^4.1.0",
+				"@aws-sdk/core": "3.873.0",
+				"@aws-sdk/types": "3.862.0",
+				"@smithy/property-provider": "^4.0.5",
+				"@smithy/shared-ini-file-loader": "^4.0.5",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1777,18 +1785,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.758.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.758.0.tgz",
-			"integrity": "sha512-x0FYJqcOLUCv8GLLFDYMXRAQKGjoM+L0BG4BiHYZRDf24yQWFCAZsCQAYKo6XZYh2qznbsW6f//qpyJ5b0QVKQ==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.873.0.tgz",
+			"integrity": "sha512-SudkAOZmjEEYgUrqlUUjvrtbWJeI54/0Xo87KRxm4kfBtMqSx0TxbplNUAk8Gkg4XQNY0o7jpG8tK7r2Wc2+uw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/client-sso": "3.758.0",
-				"@aws-sdk/core": "3.758.0",
-				"@aws-sdk/token-providers": "3.758.0",
-				"@aws-sdk/types": "3.734.0",
-				"@smithy/property-provider": "^4.0.1",
-				"@smithy/shared-ini-file-loader": "^4.0.1",
-				"@smithy/types": "^4.1.0",
+				"@aws-sdk/client-sso": "3.873.0",
+				"@aws-sdk/core": "3.873.0",
+				"@aws-sdk/token-providers": "3.873.0",
+				"@aws-sdk/types": "3.862.0",
+				"@smithy/property-provider": "^4.0.5",
+				"@smithy/shared-ini-file-loader": "^4.0.5",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1796,16 +1804,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.758.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.758.0.tgz",
-			"integrity": "sha512-XGguXhBqiCXMXRxcfCAVPlMbm3VyJTou79r/3mxWddHWF0XbhaQiBIbUz6vobVTD25YQRbWSmSch7VA8kI5Lrw==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.873.0.tgz",
+			"integrity": "sha512-Gw2H21+VkA6AgwKkBtTtlGZ45qgyRZPSKWs0kUwXVlmGOiPz61t/lBX0vG6I06ZIz2wqeTJ5OA1pWZLqw1j0JQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.758.0",
-				"@aws-sdk/nested-clients": "3.758.0",
-				"@aws-sdk/types": "3.734.0",
-				"@smithy/property-provider": "^4.0.1",
-				"@smithy/types": "^4.1.0",
+				"@aws-sdk/core": "3.873.0",
+				"@aws-sdk/nested-clients": "3.873.0",
+				"@aws-sdk/types": "3.862.0",
+				"@smithy/property-provider": "^4.0.5",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1813,14 +1821,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-host-header": {
-			"version": "3.734.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.734.0.tgz",
-			"integrity": "sha512-LW7RRgSOHHBzWZnigNsDIzu3AiwtjeI2X66v+Wn1P1u+eXssy1+up4ZY/h+t2sU4LU36UvEf+jrZti9c6vRnFw==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.873.0.tgz",
+			"integrity": "sha512-KZ/W1uruWtMOs7D5j3KquOxzCnV79KQW9MjJFZM/M0l6KI8J6V3718MXxFHsTjUE4fpdV6SeCNLV1lwGygsjJA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.734.0",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/types": "^4.1.0",
+				"@aws-sdk/types": "3.862.0",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1828,13 +1836,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-logger": {
-			"version": "3.734.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.734.0.tgz",
-			"integrity": "sha512-mUMFITpJUW3LcKvFok176eI5zXAUomVtahb9IQBwLzkqFYOrMJvWAvoV4yuxrJ8TlQBG8gyEnkb9SnhZvjg67w==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.873.0.tgz",
+			"integrity": "sha512-QhNZ8X7pW68kFez9QxUSN65Um0Feo18ZmHxszQZNUhKDsXew/EG9NPQE/HgYcekcon35zHxC4xs+FeNuPurP2g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.734.0",
-				"@smithy/types": "^4.1.0",
+				"@aws-sdk/types": "3.862.0",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1842,14 +1850,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-recursion-detection": {
-			"version": "3.734.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.734.0.tgz",
-			"integrity": "sha512-CUat2d9ITsFc2XsmeiRQO96iWpxSKYFjxvj27Hc7vo87YUHRnfMfnc8jw1EpxEwMcvBD7LsRa6vDNky6AjcrFA==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.873.0.tgz",
+			"integrity": "sha512-OtgY8EXOzRdEWR//WfPkA/fXl0+WwE8hq0y9iw2caNyKPtca85dzrrZWnPqyBK/cpImosrpR1iKMYr41XshsCg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.734.0",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/types": "^4.1.0",
+				"@aws-sdk/types": "3.862.0",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1857,17 +1865,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.758.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.758.0.tgz",
-			"integrity": "sha512-iNyehQXtQlj69JCgfaOssgZD4HeYGOwxcaKeG6F+40cwBjTAi0+Ph1yfDwqk2qiBPIRWJ/9l2LodZbxiBqgrwg==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.873.0.tgz",
+			"integrity": "sha512-gHqAMYpWkPhZLwqB3Yj83JKdL2Vsb64sryo8LN2UdpElpS+0fT4yjqSxKTfp7gkhN6TCIxF24HQgbPk5FMYJWw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.758.0",
-				"@aws-sdk/types": "3.734.0",
-				"@aws-sdk/util-endpoints": "3.743.0",
-				"@smithy/core": "^3.1.5",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/types": "^4.1.0",
+				"@aws-sdk/core": "3.873.0",
+				"@aws-sdk/types": "3.862.0",
+				"@aws-sdk/util-endpoints": "3.873.0",
+				"@smithy/core": "^3.8.0",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1875,16 +1883,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/region-config-resolver": {
-			"version": "3.734.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.734.0.tgz",
-			"integrity": "sha512-Lvj1kPRC5IuJBr9DyJ9T9/plkh+EfKLy+12s/mykOy1JaKHDpvj+XGy2YO6YgYVOb8JFtaqloid+5COtje4JTQ==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.873.0.tgz",
+			"integrity": "sha512-q9sPoef+BBG6PJnc4x60vK/bfVwvRWsPgcoQyIra057S/QGjq5VkjvNk6H8xedf6vnKlXNBwq9BaANBXnldUJg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.734.0",
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/types": "^4.1.0",
+				"@aws-sdk/types": "3.862.0",
+				"@smithy/node-config-provider": "^4.1.4",
+				"@smithy/types": "^4.3.2",
 				"@smithy/util-config-provider": "^4.0.0",
-				"@smithy/util-middleware": "^4.0.1",
+				"@smithy/util-middleware": "^4.0.5",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1892,16 +1900,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/token-providers": {
-			"version": "3.758.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.758.0.tgz",
-			"integrity": "sha512-ckptN1tNrIfQUaGWm/ayW1ddG+imbKN7HHhjFdS4VfItsP0QQOB0+Ov+tpgb4MoNR4JaUghMIVStjIeHN2ks1w==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.873.0.tgz",
+			"integrity": "sha512-BWOCeFeV/Ba8fVhtwUw/0Hz4wMm9fjXnMb4Z2a5he/jFlz5mt1/rr6IQ4MyKgzOaz24YrvqsJW2a0VUKOaYDvg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/nested-clients": "3.758.0",
-				"@aws-sdk/types": "3.734.0",
-				"@smithy/property-provider": "^4.0.1",
-				"@smithy/shared-ini-file-loader": "^4.0.1",
-				"@smithy/types": "^4.1.0",
+				"@aws-sdk/core": "3.873.0",
+				"@aws-sdk/nested-clients": "3.873.0",
+				"@aws-sdk/types": "3.862.0",
+				"@smithy/property-provider": "^4.0.5",
+				"@smithy/shared-ini-file-loader": "^4.0.5",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1909,12 +1918,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/types": {
-			"version": "3.734.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.734.0.tgz",
-			"integrity": "sha512-o11tSPTT70nAkGV1fN9wm/hAIiLPyWX6SuGf+9JyTp7S/rC2cFWhR26MvA69nplcjNaXVzB0f+QFrLXXjOqCrg==",
+			"version": "3.862.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.862.0.tgz",
+			"integrity": "sha512-Bei+RL0cDxxV+lW2UezLbCYYNeJm6Nzee0TpW0FfyTRBhH9C1XQh4+x+IClriXvgBnRquTMMYsmJfvx8iyLKrg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.1.0",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1922,14 +1931,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.743.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.743.0.tgz",
-			"integrity": "sha512-sN1l559zrixeh5x+pttrnd0A3+r34r0tmPkJ/eaaMaAzXqsmKU/xYre9K3FNnsSS1J1k4PEfk/nHDTVUgFYjnw==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.873.0.tgz",
+			"integrity": "sha512-YByHrhjxYdjKRf/RQygRK1uh0As1FIi9+jXTcIEX/rBgN8mUByczr2u4QXBzw7ZdbdcOBMOkPnLRjNOWW1MkFg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.734.0",
-				"@smithy/types": "^4.1.0",
-				"@smithy/util-endpoints": "^3.0.1",
+				"@aws-sdk/types": "3.862.0",
+				"@smithy/types": "^4.3.2",
+				"@smithy/url-parser": "^4.0.5",
+				"@smithy/util-endpoints": "^3.0.7",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1937,27 +1947,27 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/util-user-agent-browser": {
-			"version": "3.734.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.734.0.tgz",
-			"integrity": "sha512-xQTCus6Q9LwUuALW+S76OL0jcWtMOVu14q+GoLnWPUM7QeUw963oQcLhF7oq0CtaLLKyl4GOUfcwc773Zmwwng==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.873.0.tgz",
+			"integrity": "sha512-AcRdbK6o19yehEcywI43blIBhOCSo6UgyWcuOJX5CFF8k39xm1ILCjQlRRjchLAxWrm0lU0Q7XV90RiMMFMZtA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.734.0",
-				"@smithy/types": "^4.1.0",
+				"@aws-sdk/types": "3.862.0",
+				"@smithy/types": "^4.3.2",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/util-user-agent-node": {
-			"version": "3.758.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.758.0.tgz",
-			"integrity": "sha512-A5EZw85V6WhoKMV2hbuFRvb9NPlxEErb4HPO6/SPXYY4QrjprIzScHxikqcWv1w4J3apB1wto9LPU3IMsYtfrw==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.873.0.tgz",
+			"integrity": "sha512-9MivTP+q9Sis71UxuBaIY3h5jxH0vN3/ZWGxO8ADL19S2OIfknrYSAfzE5fpoKROVBu0bS4VifHOFq4PY1zsxw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/middleware-user-agent": "3.758.0",
-				"@aws-sdk/types": "3.734.0",
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/types": "^4.1.0",
+				"@aws-sdk/middleware-user-agent": "3.873.0",
+				"@aws-sdk/types": "3.862.0",
+				"@smithy/node-config-provider": "^4.1.4",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1973,12 +1983,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/abort-controller": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
-			"integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.5.tgz",
+			"integrity": "sha512-jcrqdTQurIrBbUm4W2YdLVMQDoL0sA9DTxYd2s+R/y+2U9NLOP7Xf/YqfSg1FZhlZIYEnvk2mwbyvIfdLEPo8g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.1.0",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1986,15 +1996,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/config-resolver": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.0.1.tgz",
-			"integrity": "sha512-Igfg8lKu3dRVkTSEm98QpZUvKEOa71jDX4vKRcvJVyRc3UgN3j7vFMf0s7xLQhYmKa8kyJGQgUJDOV5V3neVlQ==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.5.tgz",
+			"integrity": "sha512-viuHMxBAqydkB0AfWwHIdwf/PRH2z5KHGUzqyRtS/Wv+n3IHI993Sk76VCA7dD/+GzgGOmlJDITfPcJC1nIVIw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/types": "^4.1.0",
+				"@smithy/node-config-provider": "^4.1.4",
+				"@smithy/types": "^4.3.2",
 				"@smithy/util-config-provider": "^4.0.0",
-				"@smithy/util-middleware": "^4.0.1",
+				"@smithy/util-middleware": "^4.0.5",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2002,34 +2012,37 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/core": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.5.tgz",
-			"integrity": "sha512-HLclGWPkCsekQgsyzxLhCQLa8THWXtB5PxyYN+2O6nkyLt550KQKTlbV2D1/j5dNIQapAZM1+qFnpBFxZQkgCA==",
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.8.0.tgz",
+			"integrity": "sha512-EYqsIYJmkR1VhVE9pccnk353xhs+lB6btdutJEtsp7R055haMJp2yE16eSxw8fv+G0WUY6vqxyYOP8kOqawxYQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/middleware-serde": "^4.0.2",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/types": "^4.1.0",
+				"@smithy/middleware-serde": "^4.0.9",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/types": "^4.3.2",
+				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-body-length-browser": "^4.0.0",
-				"@smithy/util-middleware": "^4.0.1",
-				"@smithy/util-stream": "^4.1.2",
+				"@smithy/util-middleware": "^4.0.5",
+				"@smithy/util-stream": "^4.2.4",
 				"@smithy/util-utf8": "^4.0.0",
-				"tslib": "^2.6.2"
+				"@types/uuid": "^9.0.1",
+				"tslib": "^2.6.2",
+				"uuid": "^9.0.1"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/credential-provider-imds": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.1.tgz",
-			"integrity": "sha512-l/qdInaDq1Zpznpmev/+52QomsJNZ3JkTl5yrTl02V6NBgJOQ4LY0SFw/8zsMwj3tLe8vqiIuwF6nxaEwgf6mg==",
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.7.tgz",
+			"integrity": "sha512-dDzrMXA8d8riFNiPvytxn0mNwR4B3h8lgrQ5UjAGu6T9z/kRg/Xncf4tEQHE/+t25sY8IH3CowcmWi+1U5B1Gw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/property-provider": "^4.0.1",
-				"@smithy/types": "^4.1.0",
-				"@smithy/url-parser": "^4.0.1",
+				"@smithy/node-config-provider": "^4.1.4",
+				"@smithy/property-provider": "^4.0.5",
+				"@smithy/types": "^4.3.2",
+				"@smithy/url-parser": "^4.0.5",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2037,13 +2050,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/eventstream-serde-node": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.0.1.tgz",
-			"integrity": "sha512-o4CoOI6oYGYJ4zXo34U8X9szDe3oGjmHgsMGiZM0j4vtNoT+h80TLnkUcrLZR3+E6HIxqW+G+9WHAVfl0GXK0Q==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.0.5.tgz",
+			"integrity": "sha512-lGS10urI4CNzz6YlTe5EYG0YOpsSp3ra8MXyco4aqSkQDuyZPIw2hcaxDU82OUVtK7UY9hrSvgWtpsW5D4rb4g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/eventstream-serde-universal": "^4.0.1",
-				"@smithy/types": "^4.1.0",
+				"@smithy/eventstream-serde-universal": "^4.0.5",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2051,14 +2064,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/fetch-http-handler": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.1.tgz",
-			"integrity": "sha512-3aS+fP28urrMW2KTjb6z9iFow6jO8n3MFfineGbndvzGZit3taZhKWtTorf+Gp5RpFDDafeHlhfsGlDCXvUnJA==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.1.1.tgz",
+			"integrity": "sha512-61WjM0PWmZJR+SnmzaKI7t7G0UkkNFboDpzIdzSoy7TByUzlxo18Qlh9s71qug4AY4hlH/CwXdubMtkcNEb/sQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/querystring-builder": "^4.0.1",
-				"@smithy/types": "^4.1.0",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/querystring-builder": "^4.0.5",
+				"@smithy/types": "^4.3.2",
 				"@smithy/util-base64": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -2067,12 +2080,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/hash-node": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.1.tgz",
-			"integrity": "sha512-TJ6oZS+3r2Xu4emVse1YPB3Dq3d8RkZDKcPr71Nj/lJsdAP1c7oFzYqEn1IBc915TsgLl2xIJNuxCz+gLbLE0w==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.5.tgz",
+			"integrity": "sha512-cv1HHkKhpyRb6ahD8Vcfb2Hgz67vNIXEp2vnhzfxLFGRukLCNEA5QdsorbUEzXma1Rco0u3rx5VTqbM06GcZqQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.1.0",
+				"@smithy/types": "^4.3.2",
 				"@smithy/util-buffer-from": "^4.0.0",
 				"@smithy/util-utf8": "^4.0.0",
 				"tslib": "^2.6.2"
@@ -2082,226 +2095,19 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/invalid-dependency": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.1.tgz",
-			"integrity": "sha512-gdudFPf4QRQ5pzj7HEnu6FhKRi61BfH/Gk5Yf6O0KiSbr1LlVhgjThcvjdu658VE6Nve8vaIWB8/fodmS1rBPQ==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.5.tgz",
+			"integrity": "sha512-IVnb78Qtf7EJpoEVo7qJ8BEXQwgC4n3igeJNNKEj/MLYtapnx8A67Zt/J3RXAj2xSO1910zk0LdFiygSemuLow==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.1.0",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/middleware-content-length": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.1.tgz",
-			"integrity": "sha512-OGXo7w5EkB5pPiac7KNzVtfCW2vKBTZNuCctn++TTSOMpe6RZO/n6WEC1AxJINn3+vWLKW49uad3lo/u0WJ9oQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/types": "^4.1.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/middleware-endpoint": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.6.tgz",
-			"integrity": "sha512-ftpmkTHIFqgaFugcjzLZv3kzPEFsBFSnq1JsIkr2mwFzCraZVhQk2gqN51OOeRxqhbPTkRFj39Qd2V91E/mQxg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.1.5",
-				"@smithy/middleware-serde": "^4.0.2",
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/shared-ini-file-loader": "^4.0.1",
-				"@smithy/types": "^4.1.0",
-				"@smithy/url-parser": "^4.0.1",
-				"@smithy/util-middleware": "^4.0.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/middleware-retry": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.0.7.tgz",
-			"integrity": "sha512-58j9XbUPLkqAcV1kHzVX/kAR16GT+j7DUZJqwzsxh1jtz7G82caZiGyyFgUvogVfNTg3TeAOIJepGc8TXF4AVQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/service-error-classification": "^4.0.1",
-				"@smithy/smithy-client": "^4.1.6",
-				"@smithy/types": "^4.1.0",
-				"@smithy/util-middleware": "^4.0.1",
-				"@smithy/util-retry": "^4.0.1",
-				"tslib": "^2.6.2",
-				"uuid": "^9.0.1"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/middleware-serde": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.2.tgz",
-			"integrity": "sha512-Sdr5lOagCn5tt+zKsaW+U2/iwr6bI9p08wOkCp6/eL6iMbgdtc2R5Ety66rf87PeohR0ExI84Txz9GYv5ou3iQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.1.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/middleware-stack": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
-			"integrity": "sha512-dHwDmrtR/ln8UTHpaIavRSzeIk5+YZTBtLnKwDW3G2t6nAupCiQUvNzNoHBpik63fwUaJPtlnMzXbQrNFWssIA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.1.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/node-config-provider": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
-			"integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/property-provider": "^4.0.1",
-				"@smithy/shared-ini-file-loader": "^4.0.1",
-				"@smithy/types": "^4.1.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/node-http-handler": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.3.tgz",
-			"integrity": "sha512-dYCLeINNbYdvmMLtW0VdhW1biXt+PPCGazzT5ZjKw46mOtdgToQEwjqZSS9/EN8+tNs/RO0cEWG044+YZs97aA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/abort-controller": "^4.0.1",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/querystring-builder": "^4.0.1",
-				"@smithy/types": "^4.1.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/property-provider": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
-			"integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.1.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/protocol-http": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
-			"integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.1.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/querystring-builder": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.1.tgz",
-			"integrity": "sha512-wU87iWZoCbcqrwszsOewEIuq+SU2mSoBE2CcsLwE0I19m0B2gOJr1MVjxWcDQYOzHbR1xCk7AcOBbGFUYOKvdg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.1.0",
-				"@smithy/util-uri-escape": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/querystring-parser": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.1.tgz",
-			"integrity": "sha512-Ma2XC7VS9aV77+clSFylVUnPZRindhB7BbmYiNOdr+CHt/kZNJoPP0cd3QxCnCFyPXC4eybmyE98phEHkqZ5Jw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.1.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/service-error-classification": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.1.tgz",
-			"integrity": "sha512-3JNjBfOWpj/mYfjXJHB4Txc/7E4LVq32bwzE7m28GN79+M1f76XHflUaSUkhOriprPDzev9cX/M+dEB80DNDKA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/shared-ini-file-loader": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
-			"integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.1.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/signature-v4": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
-			"integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/is-array-buffer": "^4.0.0",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/types": "^4.1.0",
-				"@smithy/util-hex-encoding": "^4.0.0",
-				"@smithy/util-middleware": "^4.0.1",
-				"@smithy/util-uri-escape": "^4.0.0",
-				"@smithy/util-utf8": "^4.0.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/signature-v4/node_modules/@smithy/is-array-buffer": {
+		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/is-array-buffer": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
 			"integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
@@ -2313,18 +2119,227 @@
 				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/smithy-client": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.6.tgz",
-			"integrity": "sha512-UYDolNg6h2O0L+cJjtgSyKKvEKCOa/8FHYJnBobyeoeWDmNpXjwOAtw16ezyeu1ETuuLEOZbrynK0ZY1Lx9Jbw==",
+		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/middleware-content-length": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.5.tgz",
+			"integrity": "sha512-l1jlNZoYzoCC7p0zCtBDE5OBXZ95yMKlRlftooE5jPWQn4YBPLgsp+oeHp7iMHaTGoUdFqmHOPa8c9G3gBsRpQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.1.5",
-				"@smithy/middleware-endpoint": "^4.0.6",
-				"@smithy/middleware-stack": "^4.0.1",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/types": "^4.1.0",
-				"@smithy/util-stream": "^4.1.2",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/types": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/middleware-endpoint": {
+			"version": "4.1.18",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.18.tgz",
+			"integrity": "sha512-ZhvqcVRPZxnZlokcPaTwb+r+h4yOIOCJmx0v2d1bpVlmP465g3qpVSf7wxcq5zZdu4jb0H4yIMxuPwDJSQc3MQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.8.0",
+				"@smithy/middleware-serde": "^4.0.9",
+				"@smithy/node-config-provider": "^4.1.4",
+				"@smithy/shared-ini-file-loader": "^4.0.5",
+				"@smithy/types": "^4.3.2",
+				"@smithy/url-parser": "^4.0.5",
+				"@smithy/util-middleware": "^4.0.5",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/middleware-retry": {
+			"version": "4.1.19",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.19.tgz",
+			"integrity": "sha512-X58zx/NVECjeuUB6A8HBu4bhx72EoUz+T5jTMIyeNKx2lf+Gs9TmWPNNkH+5QF0COjpInP/xSpJGJ7xEnAklQQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/node-config-provider": "^4.1.4",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/service-error-classification": "^4.0.7",
+				"@smithy/smithy-client": "^4.4.10",
+				"@smithy/types": "^4.3.2",
+				"@smithy/util-middleware": "^4.0.5",
+				"@smithy/util-retry": "^4.0.7",
+				"@types/uuid": "^9.0.1",
+				"tslib": "^2.6.2",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/middleware-serde": {
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.9.tgz",
+			"integrity": "sha512-uAFFR4dpeoJPGz8x9mhxp+RPjo5wW0QEEIPPPbLXiRRWeCATf/Km3gKIVR5vaP8bN1kgsPhcEeh+IZvUlBv6Xg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/types": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/middleware-stack": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.5.tgz",
+			"integrity": "sha512-/yoHDXZPh3ocRVyeWQFvC44u8seu3eYzZRveCMfgMOBcNKnAmOvjbL9+Cp5XKSIi9iYA9PECUuW2teDAk8T+OQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/node-config-provider": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.4.tgz",
+			"integrity": "sha512-+UDQV/k42jLEPPHSn39l0Bmc4sB1xtdI9Gd47fzo/0PbXzJ7ylgaOByVjF5EeQIumkepnrJyfx86dPa9p47Y+w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/property-provider": "^4.0.5",
+				"@smithy/shared-ini-file-loader": "^4.0.5",
+				"@smithy/types": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/node-http-handler": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.1.1.tgz",
+			"integrity": "sha512-RHnlHqFpoVdjSPPiYy/t40Zovf3BBHc2oemgD7VsVTFFZrU5erFFe0n52OANZZ/5sbshgD93sOh5r6I35Xmpaw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/abort-controller": "^4.0.5",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/querystring-builder": "^4.0.5",
+				"@smithy/types": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/property-provider": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.5.tgz",
+			"integrity": "sha512-R/bswf59T/n9ZgfgUICAZoWYKBHcsVDurAGX88zsiUtOTA/xUAPyiT+qkNCPwFn43pZqN84M4MiUsbSGQmgFIQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/protocol-http": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.3.tgz",
+			"integrity": "sha512-fCJd2ZR7D22XhDY0l+92pUag/7je2BztPRQ01gU5bMChcyI0rlly7QFibnYHzcxDvccMjlpM/Q1ev8ceRIb48w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/querystring-builder": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.5.tgz",
+			"integrity": "sha512-NJeSCU57piZ56c+/wY+AbAw6rxCCAOZLCIniRE7wqvndqxcKKDOXzwWjrY7wGKEISfhL9gBbAaWWgHsUGedk+A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.3.2",
+				"@smithy/util-uri-escape": "^4.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/querystring-parser": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.5.tgz",
+			"integrity": "sha512-6SV7md2CzNG/WUeTjVe6Dj8noH32r4MnUeFKZrnVYsQxpGSIcphAanQMayi8jJLZAWm6pdM9ZXvKCpWOsIGg0w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/service-error-classification": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.7.tgz",
+			"integrity": "sha512-XvRHOipqpwNhEjDf2L5gJowZEm5nsxC16pAZOeEcsygdjv9A2jdOh3YoDQvOXBGTsaJk6mNWtzWalOB9976Wlg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.3.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/shared-ini-file-loader": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.5.tgz",
+			"integrity": "sha512-YVVwehRDuehgoXdEL4r1tAAzdaDgaC9EQvhK0lEbfnbrd0bd5+CTQumbdPryX3J2shT7ZqQE+jPW4lmNBAB8JQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/signature-v4": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.3.tgz",
+			"integrity": "sha512-mARDSXSEgllNzMw6N+mC+r1AQlEBO3meEAkR/UlfAgnMzJUB3goRBWgip1EAMG99wh36MDqzo86SfIX5Y+VEaw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^4.0.0",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/types": "^4.3.2",
+				"@smithy/util-hex-encoding": "^4.0.0",
+				"@smithy/util-middleware": "^4.0.5",
+				"@smithy/util-uri-escape": "^4.0.0",
+				"@smithy/util-utf8": "^4.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/smithy-client": {
+			"version": "4.4.10",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.10.tgz",
+			"integrity": "sha512-iW6HjXqN0oPtRS0NK/zzZ4zZeGESIFcxj2FkWed3mcK8jdSdHzvnCKXSjvewESKAgGKAbJRA+OsaqKhkdYRbQQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.8.0",
+				"@smithy/middleware-endpoint": "^4.1.18",
+				"@smithy/middleware-stack": "^4.0.5",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/types": "^4.3.2",
+				"@smithy/util-stream": "^4.2.4",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2332,9 +2347,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/types": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
-			"integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
+			"integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -2344,13 +2359,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/url-parser": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
-			"integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.5.tgz",
+			"integrity": "sha512-j+733Um7f1/DXjYhCbvNXABV53NyCRRA54C7bNEIxNPs0YjfRxeMKjjgm2jvTYrciZyCjsicHwQ6Q0ylo+NAUw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/querystring-parser": "^4.0.1",
-				"@smithy/types": "^4.1.0",
+				"@smithy/querystring-parser": "^4.0.5",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2408,18 +2423,6 @@
 				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
-			"integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-config-provider": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
@@ -2433,14 +2436,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-defaults-mode-browser": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.7.tgz",
-			"integrity": "sha512-CZgDDrYHLv0RUElOsmZtAnp1pIjwDVCSuZWOPhIOBvG36RDfX1Q9+6lS61xBf+qqvHoqRjHxgINeQz47cYFC2Q==",
+			"version": "4.0.26",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.26.tgz",
+			"integrity": "sha512-xgl75aHIS/3rrGp7iTxQAOELYeyiwBu+eEgAk4xfKwJJ0L8VUjhO2shsDpeil54BOFsqmk5xfdesiewbUY5tKQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/property-provider": "^4.0.1",
-				"@smithy/smithy-client": "^4.1.6",
-				"@smithy/types": "^4.1.0",
+				"@smithy/property-provider": "^4.0.5",
+				"@smithy/smithy-client": "^4.4.10",
+				"@smithy/types": "^4.3.2",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			},
@@ -2449,17 +2452,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-defaults-mode-node": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.7.tgz",
-			"integrity": "sha512-79fQW3hnfCdrfIi1soPbK3zmooRFnLpSx3Vxi6nUlqaaQeC5dm8plt4OTNDNqEEEDkvKghZSaoti684dQFVrGQ==",
+			"version": "4.0.26",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.26.tgz",
+			"integrity": "sha512-z81yyIkGiLLYVDetKTUeCZQ8x20EEzvQjrqJtb/mXnevLq2+w3XCEWTJ2pMp401b6BkEkHVfXb/cROBpVauLMQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/config-resolver": "^4.0.1",
-				"@smithy/credential-provider-imds": "^4.0.1",
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/property-provider": "^4.0.1",
-				"@smithy/smithy-client": "^4.1.6",
-				"@smithy/types": "^4.1.0",
+				"@smithy/config-resolver": "^4.1.5",
+				"@smithy/credential-provider-imds": "^4.0.7",
+				"@smithy/node-config-provider": "^4.1.4",
+				"@smithy/property-provider": "^4.0.5",
+				"@smithy/smithy-client": "^4.4.10",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2467,13 +2470,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-endpoints": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.1.tgz",
-			"integrity": "sha512-zVdUENQpdtn9jbpD9SCFK4+aSiavRb9BxEtw9ZGUR1TYo6bBHbIoi7VkrFQ0/RwZlzx0wRBaRmPclj8iAoJCLA==",
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.7.tgz",
+			"integrity": "sha512-klGBP+RpBp6V5JbrY2C/VKnHXn3d5V2YrifZbmMY8os7M6m8wdYFoO6w/fe5VkP+YVwrEktW3IWYaSQVNZJ8oQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/types": "^4.1.0",
+				"@smithy/node-config-provider": "^4.1.4",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2493,12 +2496,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-middleware": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
-			"integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.5.tgz",
+			"integrity": "sha512-N40PfqsZHRSsByGB81HhSo+uvMxEHT+9e255S53pfBw/wI6WKDI7Jw9oyu5tJTLwZzV5DsMha3ji8jk9dsHmQQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.1.0",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2506,13 +2509,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-retry": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.1.tgz",
-			"integrity": "sha512-WmRHqNVwn3kI3rKk1LsKcVgPBG6iLTBGC1iYOV3GQegwJ3E8yjzHytPt26VNzOWr1qu0xE03nK0Ug8S7T7oufw==",
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.7.tgz",
+			"integrity": "sha512-TTO6rt0ppK70alZpkjwy+3nQlTiqNfoXja+qwuAchIEAIoSZW8Qyd76dvBv3I5bCpE38APafG23Y/u270NspiQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/service-error-classification": "^4.0.1",
-				"@smithy/types": "^4.1.0",
+				"@smithy/service-error-classification": "^4.0.7",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2520,14 +2523,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@smithy/util-stream": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.1.2.tgz",
-			"integrity": "sha512-44PKEqQ303d3rlQuiDpcCcu//hV8sn+u2JBo84dWCE0rvgeiVl0IlLMagbU++o0jCWhYCsHaAt9wZuZqNe05Hw==",
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.4.tgz",
+			"integrity": "sha512-vSKnvNZX2BXzl0U2RgCLOwWaAP9x/ddd/XobPK02pCbzRm5s55M53uwb1rl/Ts7RXZvdJZerPkA+en2FDghLuQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/fetch-http-handler": "^5.0.1",
-				"@smithy/node-http-handler": "^4.0.3",
-				"@smithy/types": "^4.1.0",
+				"@smithy/fetch-http-handler": "^5.1.1",
+				"@smithy/node-http-handler": "^4.1.1",
+				"@smithy/types": "^4.3.2",
 				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-buffer-from": "^4.0.0",
 				"@smithy/util-hex-encoding": "^4.0.0",
@@ -2563,10 +2566,41 @@
 				"node": ">=18.0.0"
 			}
 		},
+		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/fast-xml-parser": {
+			"version": "5.2.5",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+			"integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"strnum": "^2.1.0"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/strnum": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+			"integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/tslib": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD"
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime/node_modules/uuid": {
 			"version": "9.0.1",
@@ -4769,6 +4803,152 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
 			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
 		},
+		"node_modules/@aws-sdk/eventstream-handler-node": {
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.873.0.tgz",
+			"integrity": "sha512-c3j9Q3RSR4+/01oHgx8b4WuD2HinVAalbsL7rJKlw86sP6ef1Gq7rVYFn74Ooh+2fIVecvX3cla/tdkR8PwBtA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.862.0",
+				"@smithy/eventstream-codec": "^4.0.5",
+				"@smithy/types": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/eventstream-handler-node/node_modules/@aws-crypto/crc32": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+			"integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/eventstream-handler-node/node_modules/@aws-sdk/types": {
+			"version": "3.862.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.862.0.tgz",
+			"integrity": "sha512-Bei+RL0cDxxV+lW2UezLbCYYNeJm6Nzee0TpW0FfyTRBhH9C1XQh4+x+IClriXvgBnRquTMMYsmJfvx8iyLKrg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/eventstream-handler-node/node_modules/@smithy/eventstream-codec": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.0.5.tgz",
+			"integrity": "sha512-miEUN+nz2UTNoRYRhRqVTJCx7jMeILdAurStT2XoS+mhokkmz1xAPp95DFW9Gxt4iF2VBqpeF9HbTQ3kY1viOA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/crc32": "5.2.0",
+				"@smithy/types": "^4.3.2",
+				"@smithy/util-hex-encoding": "^4.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/eventstream-handler-node/node_modules/@smithy/types": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
+			"integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/eventstream-handler-node/node_modules/@smithy/util-hex-encoding": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
+			"integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/eventstream-handler-node/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD"
+		},
+		"node_modules/@aws-sdk/middleware-eventstream": {
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.873.0.tgz",
+			"integrity": "sha512-x/BFHxZcfL6siwAPILmF8bGuWAmxDhrXvTlxJZOwwozWnhgRSxgxX2sitpWGvS8pL64DoABwCWSgsgyoXJlMFw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.862.0",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/types": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-eventstream/node_modules/@aws-sdk/types": {
+			"version": "3.862.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.862.0.tgz",
+			"integrity": "sha512-Bei+RL0cDxxV+lW2UezLbCYYNeJm6Nzee0TpW0FfyTRBhH9C1XQh4+x+IClriXvgBnRquTMMYsmJfvx8iyLKrg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-eventstream/node_modules/@smithy/protocol-http": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.3.tgz",
+			"integrity": "sha512-fCJd2ZR7D22XhDY0l+92pUag/7je2BztPRQ01gU5bMChcyI0rlly7QFibnYHzcxDvccMjlpM/Q1ev8ceRIb48w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-eventstream/node_modules/@smithy/types": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
+			"integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-eventstream/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD"
+		},
 		"node_modules/@aws-sdk/middleware-host-header": {
 			"version": "3.620.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
@@ -4925,48 +5105,280 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
 			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
 		},
+		"node_modules/@aws-sdk/middleware-websocket": {
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.873.0.tgz",
+			"integrity": "sha512-NLh9JmE460/WIVlsoP4vR5zbgPu50uVHXiEyr5lf34MatayiMTiC7Dd9KecKys8tppVVqahOMkOLb4/nl0hk6Q==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.862.0",
+				"@aws-sdk/util-format-url": "3.873.0",
+				"@smithy/eventstream-codec": "^4.0.5",
+				"@smithy/eventstream-serde-browser": "^4.0.5",
+				"@smithy/fetch-http-handler": "^5.1.1",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/signature-v4": "^5.1.3",
+				"@smithy/types": "^4.3.2",
+				"@smithy/util-hex-encoding": "^4.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-websocket/node_modules/@aws-crypto/crc32": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+			"integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-websocket/node_modules/@aws-sdk/types": {
+			"version": "3.862.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.862.0.tgz",
+			"integrity": "sha512-Bei+RL0cDxxV+lW2UezLbCYYNeJm6Nzee0TpW0FfyTRBhH9C1XQh4+x+IClriXvgBnRquTMMYsmJfvx8iyLKrg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-websocket/node_modules/@smithy/eventstream-codec": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.0.5.tgz",
+			"integrity": "sha512-miEUN+nz2UTNoRYRhRqVTJCx7jMeILdAurStT2XoS+mhokkmz1xAPp95DFW9Gxt4iF2VBqpeF9HbTQ3kY1viOA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/crc32": "5.2.0",
+				"@smithy/types": "^4.3.2",
+				"@smithy/util-hex-encoding": "^4.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-websocket/node_modules/@smithy/fetch-http-handler": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.1.1.tgz",
+			"integrity": "sha512-61WjM0PWmZJR+SnmzaKI7t7G0UkkNFboDpzIdzSoy7TByUzlxo18Qlh9s71qug4AY4hlH/CwXdubMtkcNEb/sQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/querystring-builder": "^4.0.5",
+				"@smithy/types": "^4.3.2",
+				"@smithy/util-base64": "^4.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-websocket/node_modules/@smithy/is-array-buffer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+			"integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-websocket/node_modules/@smithy/protocol-http": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.3.tgz",
+			"integrity": "sha512-fCJd2ZR7D22XhDY0l+92pUag/7je2BztPRQ01gU5bMChcyI0rlly7QFibnYHzcxDvccMjlpM/Q1ev8ceRIb48w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-websocket/node_modules/@smithy/querystring-builder": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.5.tgz",
+			"integrity": "sha512-NJeSCU57piZ56c+/wY+AbAw6rxCCAOZLCIniRE7wqvndqxcKKDOXzwWjrY7wGKEISfhL9gBbAaWWgHsUGedk+A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.3.2",
+				"@smithy/util-uri-escape": "^4.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-websocket/node_modules/@smithy/signature-v4": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.3.tgz",
+			"integrity": "sha512-mARDSXSEgllNzMw6N+mC+r1AQlEBO3meEAkR/UlfAgnMzJUB3goRBWgip1EAMG99wh36MDqzo86SfIX5Y+VEaw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^4.0.0",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/types": "^4.3.2",
+				"@smithy/util-hex-encoding": "^4.0.0",
+				"@smithy/util-middleware": "^4.0.5",
+				"@smithy/util-uri-escape": "^4.0.0",
+				"@smithy/util-utf8": "^4.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-websocket/node_modules/@smithy/types": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
+			"integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-websocket/node_modules/@smithy/util-base64": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
+			"integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^4.0.0",
+				"@smithy/util-utf8": "^4.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-websocket/node_modules/@smithy/util-buffer-from": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+			"integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^4.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-websocket/node_modules/@smithy/util-hex-encoding": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
+			"integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-websocket/node_modules/@smithy/util-middleware": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.5.tgz",
+			"integrity": "sha512-N40PfqsZHRSsByGB81HhSo+uvMxEHT+9e255S53pfBw/wI6WKDI7Jw9oyu5tJTLwZzV5DsMha3ji8jk9dsHmQQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-websocket/node_modules/@smithy/util-uri-escape": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
+			"integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-websocket/node_modules/@smithy/util-utf8": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+			"integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^4.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-websocket/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD"
+		},
 		"node_modules/@aws-sdk/nested-clients": {
-			"version": "3.758.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.758.0.tgz",
-			"integrity": "sha512-YZ5s7PSvyF3Mt2h1EQulCG93uybprNGbBkPmVuy/HMMfbFTt4iL3SbKjxqvOZelm86epFfj7pvK7FliI2WOEcg==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.873.0.tgz",
+			"integrity": "sha512-yg8JkRHuH/xO65rtmLOWcd9XQhxX1kAonp2CliXT44eA/23OBds6XoheY44eZeHfCTgutDLTYitvy3k9fQY6ZA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.758.0",
-				"@aws-sdk/middleware-host-header": "3.734.0",
-				"@aws-sdk/middleware-logger": "3.734.0",
-				"@aws-sdk/middleware-recursion-detection": "3.734.0",
-				"@aws-sdk/middleware-user-agent": "3.758.0",
-				"@aws-sdk/region-config-resolver": "3.734.0",
-				"@aws-sdk/types": "3.734.0",
-				"@aws-sdk/util-endpoints": "3.743.0",
-				"@aws-sdk/util-user-agent-browser": "3.734.0",
-				"@aws-sdk/util-user-agent-node": "3.758.0",
-				"@smithy/config-resolver": "^4.0.1",
-				"@smithy/core": "^3.1.5",
-				"@smithy/fetch-http-handler": "^5.0.1",
-				"@smithy/hash-node": "^4.0.1",
-				"@smithy/invalid-dependency": "^4.0.1",
-				"@smithy/middleware-content-length": "^4.0.1",
-				"@smithy/middleware-endpoint": "^4.0.6",
-				"@smithy/middleware-retry": "^4.0.7",
-				"@smithy/middleware-serde": "^4.0.2",
-				"@smithy/middleware-stack": "^4.0.1",
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/node-http-handler": "^4.0.3",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/smithy-client": "^4.1.6",
-				"@smithy/types": "^4.1.0",
-				"@smithy/url-parser": "^4.0.1",
+				"@aws-sdk/core": "3.873.0",
+				"@aws-sdk/middleware-host-header": "3.873.0",
+				"@aws-sdk/middleware-logger": "3.873.0",
+				"@aws-sdk/middleware-recursion-detection": "3.873.0",
+				"@aws-sdk/middleware-user-agent": "3.873.0",
+				"@aws-sdk/region-config-resolver": "3.873.0",
+				"@aws-sdk/types": "3.862.0",
+				"@aws-sdk/util-endpoints": "3.873.0",
+				"@aws-sdk/util-user-agent-browser": "3.873.0",
+				"@aws-sdk/util-user-agent-node": "3.873.0",
+				"@smithy/config-resolver": "^4.1.5",
+				"@smithy/core": "^3.8.0",
+				"@smithy/fetch-http-handler": "^5.1.1",
+				"@smithy/hash-node": "^4.0.5",
+				"@smithy/invalid-dependency": "^4.0.5",
+				"@smithy/middleware-content-length": "^4.0.5",
+				"@smithy/middleware-endpoint": "^4.1.18",
+				"@smithy/middleware-retry": "^4.1.19",
+				"@smithy/middleware-serde": "^4.0.9",
+				"@smithy/middleware-stack": "^4.0.5",
+				"@smithy/node-config-provider": "^4.1.4",
+				"@smithy/node-http-handler": "^4.1.1",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/smithy-client": "^4.4.10",
+				"@smithy/types": "^4.3.2",
+				"@smithy/url-parser": "^4.0.5",
 				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-body-length-browser": "^4.0.0",
 				"@smithy/util-body-length-node": "^4.0.0",
-				"@smithy/util-defaults-mode-browser": "^4.0.7",
-				"@smithy/util-defaults-mode-node": "^4.0.7",
-				"@smithy/util-endpoints": "^3.0.1",
-				"@smithy/util-middleware": "^4.0.1",
-				"@smithy/util-retry": "^4.0.1",
+				"@smithy/util-defaults-mode-browser": "^4.0.26",
+				"@smithy/util-defaults-mode-node": "^4.0.26",
+				"@smithy/util-endpoints": "^3.0.7",
+				"@smithy/util-middleware": "^4.0.5",
+				"@smithy/util-retry": "^4.0.7",
 				"@smithy/util-utf8": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -4975,21 +5387,25 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/core": {
-			"version": "3.758.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.758.0.tgz",
-			"integrity": "sha512-0RswbdR9jt/XKemaLNuxi2gGr4xGlHyGxkTdhSQzCyUe9A9OPCoLl3rIESRguQEech+oJnbHk/wuiwHqTuP9sg==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.873.0.tgz",
+			"integrity": "sha512-WrROjp8X1VvmnZ4TBzwM7RF+EB3wRaY9kQJLXw+Aes0/3zRjUXvGIlseobGJMqMEGnM0YekD2F87UaVfot1xeQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.734.0",
-				"@smithy/core": "^3.1.5",
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/property-provider": "^4.0.1",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/signature-v4": "^5.0.1",
-				"@smithy/smithy-client": "^4.1.6",
-				"@smithy/types": "^4.1.0",
-				"@smithy/util-middleware": "^4.0.1",
-				"fast-xml-parser": "4.4.1",
+				"@aws-sdk/types": "3.862.0",
+				"@aws-sdk/xml-builder": "3.873.0",
+				"@smithy/core": "^3.8.0",
+				"@smithy/node-config-provider": "^4.1.4",
+				"@smithy/property-provider": "^4.0.5",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/signature-v4": "^5.1.3",
+				"@smithy/smithy-client": "^4.4.10",
+				"@smithy/types": "^4.3.2",
+				"@smithy/util-base64": "^4.0.0",
+				"@smithy/util-body-length-browser": "^4.0.0",
+				"@smithy/util-middleware": "^4.0.5",
+				"@smithy/util-utf8": "^4.0.0",
+				"fast-xml-parser": "5.2.5",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4997,14 +5413,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-host-header": {
-			"version": "3.734.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.734.0.tgz",
-			"integrity": "sha512-LW7RRgSOHHBzWZnigNsDIzu3AiwtjeI2X66v+Wn1P1u+eXssy1+up4ZY/h+t2sU4LU36UvEf+jrZti9c6vRnFw==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.873.0.tgz",
+			"integrity": "sha512-KZ/W1uruWtMOs7D5j3KquOxzCnV79KQW9MjJFZM/M0l6KI8J6V3718MXxFHsTjUE4fpdV6SeCNLV1lwGygsjJA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.734.0",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/types": "^4.1.0",
+				"@aws-sdk/types": "3.862.0",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5012,13 +5428,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-logger": {
-			"version": "3.734.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.734.0.tgz",
-			"integrity": "sha512-mUMFITpJUW3LcKvFok176eI5zXAUomVtahb9IQBwLzkqFYOrMJvWAvoV4yuxrJ8TlQBG8gyEnkb9SnhZvjg67w==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.873.0.tgz",
+			"integrity": "sha512-QhNZ8X7pW68kFez9QxUSN65Um0Feo18ZmHxszQZNUhKDsXew/EG9NPQE/HgYcekcon35zHxC4xs+FeNuPurP2g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.734.0",
-				"@smithy/types": "^4.1.0",
+				"@aws-sdk/types": "3.862.0",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5026,14 +5442,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-recursion-detection": {
-			"version": "3.734.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.734.0.tgz",
-			"integrity": "sha512-CUat2d9ITsFc2XsmeiRQO96iWpxSKYFjxvj27Hc7vo87YUHRnfMfnc8jw1EpxEwMcvBD7LsRa6vDNky6AjcrFA==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.873.0.tgz",
+			"integrity": "sha512-OtgY8EXOzRdEWR//WfPkA/fXl0+WwE8hq0y9iw2caNyKPtca85dzrrZWnPqyBK/cpImosrpR1iKMYr41XshsCg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.734.0",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/types": "^4.1.0",
+				"@aws-sdk/types": "3.862.0",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5041,17 +5457,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.758.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.758.0.tgz",
-			"integrity": "sha512-iNyehQXtQlj69JCgfaOssgZD4HeYGOwxcaKeG6F+40cwBjTAi0+Ph1yfDwqk2qiBPIRWJ/9l2LodZbxiBqgrwg==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.873.0.tgz",
+			"integrity": "sha512-gHqAMYpWkPhZLwqB3Yj83JKdL2Vsb64sryo8LN2UdpElpS+0fT4yjqSxKTfp7gkhN6TCIxF24HQgbPk5FMYJWw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.758.0",
-				"@aws-sdk/types": "3.734.0",
-				"@aws-sdk/util-endpoints": "3.743.0",
-				"@smithy/core": "^3.1.5",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/types": "^4.1.0",
+				"@aws-sdk/core": "3.873.0",
+				"@aws-sdk/types": "3.862.0",
+				"@aws-sdk/util-endpoints": "3.873.0",
+				"@smithy/core": "^3.8.0",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5059,16 +5475,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/region-config-resolver": {
-			"version": "3.734.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.734.0.tgz",
-			"integrity": "sha512-Lvj1kPRC5IuJBr9DyJ9T9/plkh+EfKLy+12s/mykOy1JaKHDpvj+XGy2YO6YgYVOb8JFtaqloid+5COtje4JTQ==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.873.0.tgz",
+			"integrity": "sha512-q9sPoef+BBG6PJnc4x60vK/bfVwvRWsPgcoQyIra057S/QGjq5VkjvNk6H8xedf6vnKlXNBwq9BaANBXnldUJg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.734.0",
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/types": "^4.1.0",
+				"@aws-sdk/types": "3.862.0",
+				"@smithy/node-config-provider": "^4.1.4",
+				"@smithy/types": "^4.3.2",
 				"@smithy/util-config-provider": "^4.0.0",
-				"@smithy/util-middleware": "^4.0.1",
+				"@smithy/util-middleware": "^4.0.5",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5076,12 +5492,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/types": {
-			"version": "3.734.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.734.0.tgz",
-			"integrity": "sha512-o11tSPTT70nAkGV1fN9wm/hAIiLPyWX6SuGf+9JyTp7S/rC2cFWhR26MvA69nplcjNaXVzB0f+QFrLXXjOqCrg==",
+			"version": "3.862.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.862.0.tgz",
+			"integrity": "sha512-Bei+RL0cDxxV+lW2UezLbCYYNeJm6Nzee0TpW0FfyTRBhH9C1XQh4+x+IClriXvgBnRquTMMYsmJfvx8iyLKrg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.1.0",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5089,14 +5505,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.743.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.743.0.tgz",
-			"integrity": "sha512-sN1l559zrixeh5x+pttrnd0A3+r34r0tmPkJ/eaaMaAzXqsmKU/xYre9K3FNnsSS1J1k4PEfk/nHDTVUgFYjnw==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.873.0.tgz",
+			"integrity": "sha512-YByHrhjxYdjKRf/RQygRK1uh0As1FIi9+jXTcIEX/rBgN8mUByczr2u4QXBzw7ZdbdcOBMOkPnLRjNOWW1MkFg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.734.0",
-				"@smithy/types": "^4.1.0",
-				"@smithy/util-endpoints": "^3.0.1",
+				"@aws-sdk/types": "3.862.0",
+				"@smithy/types": "^4.3.2",
+				"@smithy/url-parser": "^4.0.5",
+				"@smithy/util-endpoints": "^3.0.7",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5104,27 +5521,27 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-user-agent-browser": {
-			"version": "3.734.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.734.0.tgz",
-			"integrity": "sha512-xQTCus6Q9LwUuALW+S76OL0jcWtMOVu14q+GoLnWPUM7QeUw963oQcLhF7oq0CtaLLKyl4GOUfcwc773Zmwwng==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.873.0.tgz",
+			"integrity": "sha512-AcRdbK6o19yehEcywI43blIBhOCSo6UgyWcuOJX5CFF8k39xm1ILCjQlRRjchLAxWrm0lU0Q7XV90RiMMFMZtA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "3.734.0",
-				"@smithy/types": "^4.1.0",
+				"@aws-sdk/types": "3.862.0",
+				"@smithy/types": "^4.3.2",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-user-agent-node": {
-			"version": "3.758.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.758.0.tgz",
-			"integrity": "sha512-A5EZw85V6WhoKMV2hbuFRvb9NPlxEErb4HPO6/SPXYY4QrjprIzScHxikqcWv1w4J3apB1wto9LPU3IMsYtfrw==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.873.0.tgz",
+			"integrity": "sha512-9MivTP+q9Sis71UxuBaIY3h5jxH0vN3/ZWGxO8ADL19S2OIfknrYSAfzE5fpoKROVBu0bS4VifHOFq4PY1zsxw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/middleware-user-agent": "3.758.0",
-				"@aws-sdk/types": "3.734.0",
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/types": "^4.1.0",
+				"@aws-sdk/middleware-user-agent": "3.873.0",
+				"@aws-sdk/types": "3.862.0",
+				"@smithy/node-config-provider": "^4.1.4",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5140,12 +5557,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/abort-controller": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
-			"integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.5.tgz",
+			"integrity": "sha512-jcrqdTQurIrBbUm4W2YdLVMQDoL0sA9DTxYd2s+R/y+2U9NLOP7Xf/YqfSg1FZhlZIYEnvk2mwbyvIfdLEPo8g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.1.0",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5153,15 +5570,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/config-resolver": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.0.1.tgz",
-			"integrity": "sha512-Igfg8lKu3dRVkTSEm98QpZUvKEOa71jDX4vKRcvJVyRc3UgN3j7vFMf0s7xLQhYmKa8kyJGQgUJDOV5V3neVlQ==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.5.tgz",
+			"integrity": "sha512-viuHMxBAqydkB0AfWwHIdwf/PRH2z5KHGUzqyRtS/Wv+n3IHI993Sk76VCA7dD/+GzgGOmlJDITfPcJC1nIVIw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/types": "^4.1.0",
+				"@smithy/node-config-provider": "^4.1.4",
+				"@smithy/types": "^4.3.2",
 				"@smithy/util-config-provider": "^4.0.0",
-				"@smithy/util-middleware": "^4.0.1",
+				"@smithy/util-middleware": "^4.0.5",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5169,34 +5586,37 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/core": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.5.tgz",
-			"integrity": "sha512-HLclGWPkCsekQgsyzxLhCQLa8THWXtB5PxyYN+2O6nkyLt550KQKTlbV2D1/j5dNIQapAZM1+qFnpBFxZQkgCA==",
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.8.0.tgz",
+			"integrity": "sha512-EYqsIYJmkR1VhVE9pccnk353xhs+lB6btdutJEtsp7R055haMJp2yE16eSxw8fv+G0WUY6vqxyYOP8kOqawxYQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/middleware-serde": "^4.0.2",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/types": "^4.1.0",
+				"@smithy/middleware-serde": "^4.0.9",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/types": "^4.3.2",
+				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-body-length-browser": "^4.0.0",
-				"@smithy/util-middleware": "^4.0.1",
-				"@smithy/util-stream": "^4.1.2",
+				"@smithy/util-middleware": "^4.0.5",
+				"@smithy/util-stream": "^4.2.4",
 				"@smithy/util-utf8": "^4.0.0",
-				"tslib": "^2.6.2"
+				"@types/uuid": "^9.0.1",
+				"tslib": "^2.6.2",
+				"uuid": "^9.0.1"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/credential-provider-imds": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.1.tgz",
-			"integrity": "sha512-l/qdInaDq1Zpznpmev/+52QomsJNZ3JkTl5yrTl02V6NBgJOQ4LY0SFw/8zsMwj3tLe8vqiIuwF6nxaEwgf6mg==",
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.7.tgz",
+			"integrity": "sha512-dDzrMXA8d8riFNiPvytxn0mNwR4B3h8lgrQ5UjAGu6T9z/kRg/Xncf4tEQHE/+t25sY8IH3CowcmWi+1U5B1Gw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/property-provider": "^4.0.1",
-				"@smithy/types": "^4.1.0",
-				"@smithy/url-parser": "^4.0.1",
+				"@smithy/node-config-provider": "^4.1.4",
+				"@smithy/property-provider": "^4.0.5",
+				"@smithy/types": "^4.3.2",
+				"@smithy/url-parser": "^4.0.5",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5204,14 +5624,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/fetch-http-handler": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.1.tgz",
-			"integrity": "sha512-3aS+fP28urrMW2KTjb6z9iFow6jO8n3MFfineGbndvzGZit3taZhKWtTorf+Gp5RpFDDafeHlhfsGlDCXvUnJA==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.1.1.tgz",
+			"integrity": "sha512-61WjM0PWmZJR+SnmzaKI7t7G0UkkNFboDpzIdzSoy7TByUzlxo18Qlh9s71qug4AY4hlH/CwXdubMtkcNEb/sQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/querystring-builder": "^4.0.1",
-				"@smithy/types": "^4.1.0",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/querystring-builder": "^4.0.5",
+				"@smithy/types": "^4.3.2",
 				"@smithy/util-base64": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -5220,12 +5640,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/hash-node": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.1.tgz",
-			"integrity": "sha512-TJ6oZS+3r2Xu4emVse1YPB3Dq3d8RkZDKcPr71Nj/lJsdAP1c7oFzYqEn1IBc915TsgLl2xIJNuxCz+gLbLE0w==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.5.tgz",
+			"integrity": "sha512-cv1HHkKhpyRb6ahD8Vcfb2Hgz67vNIXEp2vnhzfxLFGRukLCNEA5QdsorbUEzXma1Rco0u3rx5VTqbM06GcZqQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.1.0",
+				"@smithy/types": "^4.3.2",
 				"@smithy/util-buffer-from": "^4.0.0",
 				"@smithy/util-utf8": "^4.0.0",
 				"tslib": "^2.6.2"
@@ -5235,12 +5655,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/invalid-dependency": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.1.tgz",
-			"integrity": "sha512-gdudFPf4QRQ5pzj7HEnu6FhKRi61BfH/Gk5Yf6O0KiSbr1LlVhgjThcvjdu658VE6Nve8vaIWB8/fodmS1rBPQ==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.5.tgz",
+			"integrity": "sha512-IVnb78Qtf7EJpoEVo7qJ8BEXQwgC4n3igeJNNKEj/MLYtapnx8A67Zt/J3RXAj2xSO1910zk0LdFiygSemuLow==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.1.0",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5260,13 +5680,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-content-length": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.1.tgz",
-			"integrity": "sha512-OGXo7w5EkB5pPiac7KNzVtfCW2vKBTZNuCctn++TTSOMpe6RZO/n6WEC1AxJINn3+vWLKW49uad3lo/u0WJ9oQ==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.5.tgz",
+			"integrity": "sha512-l1jlNZoYzoCC7p0zCtBDE5OBXZ95yMKlRlftooE5jPWQn4YBPLgsp+oeHp7iMHaTGoUdFqmHOPa8c9G3gBsRpQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/types": "^4.1.0",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5274,18 +5694,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-endpoint": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.6.tgz",
-			"integrity": "sha512-ftpmkTHIFqgaFugcjzLZv3kzPEFsBFSnq1JsIkr2mwFzCraZVhQk2gqN51OOeRxqhbPTkRFj39Qd2V91E/mQxg==",
+			"version": "4.1.18",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.18.tgz",
+			"integrity": "sha512-ZhvqcVRPZxnZlokcPaTwb+r+h4yOIOCJmx0v2d1bpVlmP465g3qpVSf7wxcq5zZdu4jb0H4yIMxuPwDJSQc3MQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.1.5",
-				"@smithy/middleware-serde": "^4.0.2",
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/shared-ini-file-loader": "^4.0.1",
-				"@smithy/types": "^4.1.0",
-				"@smithy/url-parser": "^4.0.1",
-				"@smithy/util-middleware": "^4.0.1",
+				"@smithy/core": "^3.8.0",
+				"@smithy/middleware-serde": "^4.0.9",
+				"@smithy/node-config-provider": "^4.1.4",
+				"@smithy/shared-ini-file-loader": "^4.0.5",
+				"@smithy/types": "^4.3.2",
+				"@smithy/url-parser": "^4.0.5",
+				"@smithy/util-middleware": "^4.0.5",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5293,18 +5713,19 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-retry": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.0.7.tgz",
-			"integrity": "sha512-58j9XbUPLkqAcV1kHzVX/kAR16GT+j7DUZJqwzsxh1jtz7G82caZiGyyFgUvogVfNTg3TeAOIJepGc8TXF4AVQ==",
+			"version": "4.1.19",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.19.tgz",
+			"integrity": "sha512-X58zx/NVECjeuUB6A8HBu4bhx72EoUz+T5jTMIyeNKx2lf+Gs9TmWPNNkH+5QF0COjpInP/xSpJGJ7xEnAklQQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/service-error-classification": "^4.0.1",
-				"@smithy/smithy-client": "^4.1.6",
-				"@smithy/types": "^4.1.0",
-				"@smithy/util-middleware": "^4.0.1",
-				"@smithy/util-retry": "^4.0.1",
+				"@smithy/node-config-provider": "^4.1.4",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/service-error-classification": "^4.0.7",
+				"@smithy/smithy-client": "^4.4.10",
+				"@smithy/types": "^4.3.2",
+				"@smithy/util-middleware": "^4.0.5",
+				"@smithy/util-retry": "^4.0.7",
+				"@types/uuid": "^9.0.1",
 				"tslib": "^2.6.2",
 				"uuid": "^9.0.1"
 			},
@@ -5313,12 +5734,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-serde": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.2.tgz",
-			"integrity": "sha512-Sdr5lOagCn5tt+zKsaW+U2/iwr6bI9p08wOkCp6/eL6iMbgdtc2R5Ety66rf87PeohR0ExI84Txz9GYv5ou3iQ==",
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.9.tgz",
+			"integrity": "sha512-uAFFR4dpeoJPGz8x9mhxp+RPjo5wW0QEEIPPPbLXiRRWeCATf/Km3gKIVR5vaP8bN1kgsPhcEeh+IZvUlBv6Xg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.1.0",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5326,12 +5748,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-stack": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
-			"integrity": "sha512-dHwDmrtR/ln8UTHpaIavRSzeIk5+YZTBtLnKwDW3G2t6nAupCiQUvNzNoHBpik63fwUaJPtlnMzXbQrNFWssIA==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.5.tgz",
+			"integrity": "sha512-/yoHDXZPh3ocRVyeWQFvC44u8seu3eYzZRveCMfgMOBcNKnAmOvjbL9+Cp5XKSIi9iYA9PECUuW2teDAk8T+OQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.1.0",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5339,14 +5761,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-config-provider": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
-			"integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.4.tgz",
+			"integrity": "sha512-+UDQV/k42jLEPPHSn39l0Bmc4sB1xtdI9Gd47fzo/0PbXzJ7ylgaOByVjF5EeQIumkepnrJyfx86dPa9p47Y+w==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/property-provider": "^4.0.1",
-				"@smithy/shared-ini-file-loader": "^4.0.1",
-				"@smithy/types": "^4.1.0",
+				"@smithy/property-provider": "^4.0.5",
+				"@smithy/shared-ini-file-loader": "^4.0.5",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5354,15 +5776,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.3.tgz",
-			"integrity": "sha512-dYCLeINNbYdvmMLtW0VdhW1biXt+PPCGazzT5ZjKw46mOtdgToQEwjqZSS9/EN8+tNs/RO0cEWG044+YZs97aA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.1.1.tgz",
+			"integrity": "sha512-RHnlHqFpoVdjSPPiYy/t40Zovf3BBHc2oemgD7VsVTFFZrU5erFFe0n52OANZZ/5sbshgD93sOh5r6I35Xmpaw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/abort-controller": "^4.0.1",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/querystring-builder": "^4.0.1",
-				"@smithy/types": "^4.1.0",
+				"@smithy/abort-controller": "^4.0.5",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/querystring-builder": "^4.0.5",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5370,12 +5792,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/property-provider": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
-			"integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.5.tgz",
+			"integrity": "sha512-R/bswf59T/n9ZgfgUICAZoWYKBHcsVDurAGX88zsiUtOTA/xUAPyiT+qkNCPwFn43pZqN84M4MiUsbSGQmgFIQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.1.0",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5383,12 +5805,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/protocol-http": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
-			"integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.3.tgz",
+			"integrity": "sha512-fCJd2ZR7D22XhDY0l+92pUag/7je2BztPRQ01gU5bMChcyI0rlly7QFibnYHzcxDvccMjlpM/Q1ev8ceRIb48w==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.1.0",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5396,12 +5818,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/querystring-builder": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.1.tgz",
-			"integrity": "sha512-wU87iWZoCbcqrwszsOewEIuq+SU2mSoBE2CcsLwE0I19m0B2gOJr1MVjxWcDQYOzHbR1xCk7AcOBbGFUYOKvdg==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.5.tgz",
+			"integrity": "sha512-NJeSCU57piZ56c+/wY+AbAw6rxCCAOZLCIniRE7wqvndqxcKKDOXzwWjrY7wGKEISfhL9gBbAaWWgHsUGedk+A==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.1.0",
+				"@smithy/types": "^4.3.2",
 				"@smithy/util-uri-escape": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -5410,12 +5832,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/querystring-parser": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.1.tgz",
-			"integrity": "sha512-Ma2XC7VS9aV77+clSFylVUnPZRindhB7BbmYiNOdr+CHt/kZNJoPP0cd3QxCnCFyPXC4eybmyE98phEHkqZ5Jw==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.5.tgz",
+			"integrity": "sha512-6SV7md2CzNG/WUeTjVe6Dj8noH32r4MnUeFKZrnVYsQxpGSIcphAanQMayi8jJLZAWm6pdM9ZXvKCpWOsIGg0w==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.1.0",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5423,24 +5845,24 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/service-error-classification": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.1.tgz",
-			"integrity": "sha512-3JNjBfOWpj/mYfjXJHB4Txc/7E4LVq32bwzE7m28GN79+M1f76XHflUaSUkhOriprPDzev9cX/M+dEB80DNDKA==",
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.7.tgz",
+			"integrity": "sha512-XvRHOipqpwNhEjDf2L5gJowZEm5nsxC16pAZOeEcsygdjv9A2jdOh3YoDQvOXBGTsaJk6mNWtzWalOB9976Wlg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.1.0"
+				"@smithy/types": "^4.3.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/shared-ini-file-loader": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
-			"integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.5.tgz",
+			"integrity": "sha512-YVVwehRDuehgoXdEL4r1tAAzdaDgaC9EQvhK0lEbfnbrd0bd5+CTQumbdPryX3J2shT7ZqQE+jPW4lmNBAB8JQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.1.0",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5448,16 +5870,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/signature-v4": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
-			"integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.3.tgz",
+			"integrity": "sha512-mARDSXSEgllNzMw6N+mC+r1AQlEBO3meEAkR/UlfAgnMzJUB3goRBWgip1EAMG99wh36MDqzo86SfIX5Y+VEaw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/is-array-buffer": "^4.0.0",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/types": "^4.1.0",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/types": "^4.3.2",
 				"@smithy/util-hex-encoding": "^4.0.0",
-				"@smithy/util-middleware": "^4.0.1",
+				"@smithy/util-middleware": "^4.0.5",
 				"@smithy/util-uri-escape": "^4.0.0",
 				"@smithy/util-utf8": "^4.0.0",
 				"tslib": "^2.6.2"
@@ -5467,17 +5889,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/smithy-client": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.6.tgz",
-			"integrity": "sha512-UYDolNg6h2O0L+cJjtgSyKKvEKCOa/8FHYJnBobyeoeWDmNpXjwOAtw16ezyeu1ETuuLEOZbrynK0ZY1Lx9Jbw==",
+			"version": "4.4.10",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.10.tgz",
+			"integrity": "sha512-iW6HjXqN0oPtRS0NK/zzZ4zZeGESIFcxj2FkWed3mcK8jdSdHzvnCKXSjvewESKAgGKAbJRA+OsaqKhkdYRbQQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.1.5",
-				"@smithy/middleware-endpoint": "^4.0.6",
-				"@smithy/middleware-stack": "^4.0.1",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/types": "^4.1.0",
-				"@smithy/util-stream": "^4.1.2",
+				"@smithy/core": "^3.8.0",
+				"@smithy/middleware-endpoint": "^4.1.18",
+				"@smithy/middleware-stack": "^4.0.5",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/types": "^4.3.2",
+				"@smithy/util-stream": "^4.2.4",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5485,9 +5907,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/types": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
-			"integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
+			"integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -5497,13 +5919,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/url-parser": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
-			"integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.5.tgz",
+			"integrity": "sha512-j+733Um7f1/DXjYhCbvNXABV53NyCRRA54C7bNEIxNPs0YjfRxeMKjjgm2jvTYrciZyCjsicHwQ6Q0ylo+NAUw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/querystring-parser": "^4.0.1",
-				"@smithy/types": "^4.1.0",
+				"@smithy/querystring-parser": "^4.0.5",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5574,14 +5996,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-defaults-mode-browser": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.7.tgz",
-			"integrity": "sha512-CZgDDrYHLv0RUElOsmZtAnp1pIjwDVCSuZWOPhIOBvG36RDfX1Q9+6lS61xBf+qqvHoqRjHxgINeQz47cYFC2Q==",
+			"version": "4.0.26",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.26.tgz",
+			"integrity": "sha512-xgl75aHIS/3rrGp7iTxQAOELYeyiwBu+eEgAk4xfKwJJ0L8VUjhO2shsDpeil54BOFsqmk5xfdesiewbUY5tKQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/property-provider": "^4.0.1",
-				"@smithy/smithy-client": "^4.1.6",
-				"@smithy/types": "^4.1.0",
+				"@smithy/property-provider": "^4.0.5",
+				"@smithy/smithy-client": "^4.4.10",
+				"@smithy/types": "^4.3.2",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			},
@@ -5590,17 +6012,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-defaults-mode-node": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.7.tgz",
-			"integrity": "sha512-79fQW3hnfCdrfIi1soPbK3zmooRFnLpSx3Vxi6nUlqaaQeC5dm8plt4OTNDNqEEEDkvKghZSaoti684dQFVrGQ==",
+			"version": "4.0.26",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.26.tgz",
+			"integrity": "sha512-z81yyIkGiLLYVDetKTUeCZQ8x20EEzvQjrqJtb/mXnevLq2+w3XCEWTJ2pMp401b6BkEkHVfXb/cROBpVauLMQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/config-resolver": "^4.0.1",
-				"@smithy/credential-provider-imds": "^4.0.1",
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/property-provider": "^4.0.1",
-				"@smithy/smithy-client": "^4.1.6",
-				"@smithy/types": "^4.1.0",
+				"@smithy/config-resolver": "^4.1.5",
+				"@smithy/credential-provider-imds": "^4.0.7",
+				"@smithy/node-config-provider": "^4.1.4",
+				"@smithy/property-provider": "^4.0.5",
+				"@smithy/smithy-client": "^4.4.10",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5608,13 +6030,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-endpoints": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.1.tgz",
-			"integrity": "sha512-zVdUENQpdtn9jbpD9SCFK4+aSiavRb9BxEtw9ZGUR1TYo6bBHbIoi7VkrFQ0/RwZlzx0wRBaRmPclj8iAoJCLA==",
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.7.tgz",
+			"integrity": "sha512-klGBP+RpBp6V5JbrY2C/VKnHXn3d5V2YrifZbmMY8os7M6m8wdYFoO6w/fe5VkP+YVwrEktW3IWYaSQVNZJ8oQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/types": "^4.1.0",
+				"@smithy/node-config-provider": "^4.1.4",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5634,12 +6056,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-middleware": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
-			"integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.5.tgz",
+			"integrity": "sha512-N40PfqsZHRSsByGB81HhSo+uvMxEHT+9e255S53pfBw/wI6WKDI7Jw9oyu5tJTLwZzV5DsMha3ji8jk9dsHmQQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.1.0",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5647,13 +6069,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-retry": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.1.tgz",
-			"integrity": "sha512-WmRHqNVwn3kI3rKk1LsKcVgPBG6iLTBGC1iYOV3GQegwJ3E8yjzHytPt26VNzOWr1qu0xE03nK0Ug8S7T7oufw==",
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.7.tgz",
+			"integrity": "sha512-TTO6rt0ppK70alZpkjwy+3nQlTiqNfoXja+qwuAchIEAIoSZW8Qyd76dvBv3I5bCpE38APafG23Y/u270NspiQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/service-error-classification": "^4.0.1",
-				"@smithy/types": "^4.1.0",
+				"@smithy/service-error-classification": "^4.0.7",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5661,14 +6083,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-stream": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.1.2.tgz",
-			"integrity": "sha512-44PKEqQ303d3rlQuiDpcCcu//hV8sn+u2JBo84dWCE0rvgeiVl0IlLMagbU++o0jCWhYCsHaAt9wZuZqNe05Hw==",
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.4.tgz",
+			"integrity": "sha512-vSKnvNZX2BXzl0U2RgCLOwWaAP9x/ddd/XobPK02pCbzRm5s55M53uwb1rl/Ts7RXZvdJZerPkA+en2FDghLuQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/fetch-http-handler": "^5.0.1",
-				"@smithy/node-http-handler": "^4.0.3",
-				"@smithy/types": "^4.1.0",
+				"@smithy/fetch-http-handler": "^5.1.1",
+				"@smithy/node-http-handler": "^4.1.1",
+				"@smithy/types": "^4.3.2",
 				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-buffer-from": "^4.0.0",
 				"@smithy/util-hex-encoding": "^4.0.0",
@@ -5703,6 +6125,36 @@
 			"engines": {
 				"node": ">=18.0.0"
 			}
+		},
+		"node_modules/@aws-sdk/nested-clients/node_modules/fast-xml-parser": {
+			"version": "5.2.5",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+			"integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"strnum": "^2.1.0"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients/node_modules/strnum": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+			"integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/@aws-sdk/nested-clients/node_modules/tslib": {
 			"version": "2.8.1",
@@ -5847,6 +6299,78 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
 			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
 		},
+		"node_modules/@aws-sdk/util-format-url": {
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.873.0.tgz",
+			"integrity": "sha512-v//b9jFnhzTKKV3HFTw2MakdM22uBAs2lBov51BWmFXuFtSTdBLrR7zgfetQPE3PVkFai0cmtJQPdc3MX+T/cQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "3.862.0",
+				"@smithy/querystring-builder": "^4.0.5",
+				"@smithy/types": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-format-url/node_modules/@aws-sdk/types": {
+			"version": "3.862.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.862.0.tgz",
+			"integrity": "sha512-Bei+RL0cDxxV+lW2UezLbCYYNeJm6Nzee0TpW0FfyTRBhH9C1XQh4+x+IClriXvgBnRquTMMYsmJfvx8iyLKrg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-format-url/node_modules/@smithy/querystring-builder": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.5.tgz",
+			"integrity": "sha512-NJeSCU57piZ56c+/wY+AbAw6rxCCAOZLCIniRE7wqvndqxcKKDOXzwWjrY7wGKEISfhL9gBbAaWWgHsUGedk+A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.3.2",
+				"@smithy/util-uri-escape": "^4.0.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-format-url/node_modules/@smithy/types": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
+			"integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-format-url/node_modules/@smithy/util-uri-escape": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
+			"integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-format-url/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD"
+		},
 		"node_modules/@aws-sdk/util-locate-window": {
 			"version": "3.568.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.568.0.tgz",
@@ -5938,6 +6462,37 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-utf8-browser/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD"
+		},
+		"node_modules/@aws-sdk/xml-builder": {
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.873.0.tgz",
+			"integrity": "sha512-kLO7k7cGJ6KaHiExSJWojZurF7SnGMDHXRuQunFnEoD0n1yB6Lqy/S/zHiQ7oJnBhPr9q0TW9qFkrsZb1Uc54w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/xml-builder/node_modules/@smithy/types": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
+			"integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/xml-builder/node_modules/tslib": {
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
@@ -13503,13 +14058,13 @@
 			"license": "0BSD"
 		},
 		"node_modules/@smithy/eventstream-serde-browser": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.0.3.tgz",
-			"integrity": "sha512-oe1d/tfCGVZBMX8O6HApaM4G+fF9JNdyLP7tWXt00epuL/kLOdp/4o9VqheLFeJaXgao+9IaBgs/q/oM48hxzg==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.0.5.tgz",
+			"integrity": "sha512-LCUQUVTbM6HFKzImYlSB9w4xafZmpdmZsOh9rIl7riPC3osCgGFVP+wwvYVw6pXda9PPT9TcEZxaq3XE81EdJQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/eventstream-serde-universal": "^4.0.3",
-				"@smithy/types": "^4.3.0",
+				"@smithy/eventstream-serde-universal": "^4.0.5",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -13517,9 +14072,9 @@
 			}
 		},
 		"node_modules/@smithy/eventstream-serde-browser/node_modules/@smithy/types": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.0.tgz",
-			"integrity": "sha512-+1iaIQHthDh9yaLhRzaoQxRk+l9xlk+JjMFxGRhNLz+m9vKOkjNeU8QuB4w3xvzHyVR/BVlp/4AXDHjoRIkfgQ==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
+			"integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -13535,12 +14090,12 @@
 			"license": "0BSD"
 		},
 		"node_modules/@smithy/eventstream-serde-config-resolver": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.1.1.tgz",
-			"integrity": "sha512-XXCPGjRNwpFWHKQJMKIjGLfFKYULYckFnxGcWmBC2mBf3NsrvUKgqHax4NCqc0TfbDAimPDHOc6HOKtzsXK9Gw==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.1.3.tgz",
+			"integrity": "sha512-yTTzw2jZjn/MbHu1pURbHdpjGbCuMHWncNBpJnQAPxOVnFUAbSIUSwafiphVDjNV93TdBJWmeVAds7yl5QCkcA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.3.0",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -13548,9 +14103,9 @@
 			}
 		},
 		"node_modules/@smithy/eventstream-serde-config-resolver/node_modules/@smithy/types": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.0.tgz",
-			"integrity": "sha512-+1iaIQHthDh9yaLhRzaoQxRk+l9xlk+JjMFxGRhNLz+m9vKOkjNeU8QuB4w3xvzHyVR/BVlp/4AXDHjoRIkfgQ==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
+			"integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -13597,13 +14152,13 @@
 			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
 		},
 		"node_modules/@smithy/eventstream-serde-universal": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.0.3.tgz",
-			"integrity": "sha512-ShOP512CZrYI9n+h64PJ84udzoNHUQtPddyh1j175KNTKsSnMEDNscOWJWyEoLQiuhWWw51lSa+k6ea9ZGXcRg==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.0.5.tgz",
+			"integrity": "sha512-JFnmu4SU36YYw3DIBVao3FsJh4Uw65vVDIqlWT4LzR6gXA0F3KP0IXFKKJrhaVzCBhAuMsrUUaT5I+/4ZhF7aw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/eventstream-codec": "^4.0.3",
-				"@smithy/types": "^4.3.0",
+				"@smithy/eventstream-codec": "^4.0.5",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -13625,13 +14180,13 @@
 			}
 		},
 		"node_modules/@smithy/eventstream-serde-universal/node_modules/@smithy/eventstream-codec": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.0.3.tgz",
-			"integrity": "sha512-V22KIPXZsE2mc4zEgYGANM/7UbL9jWlOACEolyGyMuTY+jjHJ2PQ0FdopOTS1CS7u6PlAkALmypkv2oQ4aftcg==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.0.5.tgz",
+			"integrity": "sha512-miEUN+nz2UTNoRYRhRqVTJCx7jMeILdAurStT2XoS+mhokkmz1xAPp95DFW9Gxt4iF2VBqpeF9HbTQ3kY1viOA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/crc32": "5.2.0",
-				"@smithy/types": "^4.3.0",
+				"@smithy/types": "^4.3.2",
 				"@smithy/util-hex-encoding": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -13640,9 +14195,9 @@
 			}
 		},
 		"node_modules/@smithy/eventstream-serde-universal/node_modules/@smithy/types": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.0.tgz",
-			"integrity": "sha512-+1iaIQHthDh9yaLhRzaoQxRk+l9xlk+JjMFxGRhNLz+m9vKOkjNeU8QuB4w3xvzHyVR/BVlp/4AXDHjoRIkfgQ==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
+			"integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -33102,51 +33657,55 @@
 			}
 		},
 		"@aws-sdk/client-bedrock-runtime": {
-			"version": "3.758.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.758.0.tgz",
-			"integrity": "sha512-T7s+fULUxN3AcJP+lgoUKLawzVEtyCTi+5Ga+wrHnqEPwAsM/wg7VctsZfow1fCgARLT/lzmP2LTCi8ycRnQWg==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.873.0.tgz",
+			"integrity": "sha512-g2nTwBLudYtugLuFcnJWwPNU9wPvrt1PaMthsBL8KXG7Q3DPRjK2n3jq7JO12U5Zr0oYNzXju2gRybrVrma9zA==",
 			"requires": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.758.0",
-				"@aws-sdk/credential-provider-node": "3.758.0",
-				"@aws-sdk/middleware-host-header": "3.734.0",
-				"@aws-sdk/middleware-logger": "3.734.0",
-				"@aws-sdk/middleware-recursion-detection": "3.734.0",
-				"@aws-sdk/middleware-user-agent": "3.758.0",
-				"@aws-sdk/region-config-resolver": "3.734.0",
-				"@aws-sdk/types": "3.734.0",
-				"@aws-sdk/util-endpoints": "3.743.0",
-				"@aws-sdk/util-user-agent-browser": "3.734.0",
-				"@aws-sdk/util-user-agent-node": "3.758.0",
-				"@smithy/config-resolver": "^4.0.1",
-				"@smithy/core": "^3.1.5",
-				"@smithy/eventstream-serde-browser": "^4.0.1",
-				"@smithy/eventstream-serde-config-resolver": "^4.0.1",
-				"@smithy/eventstream-serde-node": "^4.0.1",
-				"@smithy/fetch-http-handler": "^5.0.1",
-				"@smithy/hash-node": "^4.0.1",
-				"@smithy/invalid-dependency": "^4.0.1",
-				"@smithy/middleware-content-length": "^4.0.1",
-				"@smithy/middleware-endpoint": "^4.0.6",
-				"@smithy/middleware-retry": "^4.0.7",
-				"@smithy/middleware-serde": "^4.0.2",
-				"@smithy/middleware-stack": "^4.0.1",
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/node-http-handler": "^4.0.3",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/smithy-client": "^4.1.6",
-				"@smithy/types": "^4.1.0",
-				"@smithy/url-parser": "^4.0.1",
+				"@aws-sdk/core": "3.873.0",
+				"@aws-sdk/credential-provider-node": "3.873.0",
+				"@aws-sdk/eventstream-handler-node": "3.873.0",
+				"@aws-sdk/middleware-eventstream": "3.873.0",
+				"@aws-sdk/middleware-host-header": "3.873.0",
+				"@aws-sdk/middleware-logger": "3.873.0",
+				"@aws-sdk/middleware-recursion-detection": "3.873.0",
+				"@aws-sdk/middleware-user-agent": "3.873.0",
+				"@aws-sdk/middleware-websocket": "3.873.0",
+				"@aws-sdk/region-config-resolver": "3.873.0",
+				"@aws-sdk/token-providers": "3.873.0",
+				"@aws-sdk/types": "3.862.0",
+				"@aws-sdk/util-endpoints": "3.873.0",
+				"@aws-sdk/util-user-agent-browser": "3.873.0",
+				"@aws-sdk/util-user-agent-node": "3.873.0",
+				"@smithy/config-resolver": "^4.1.5",
+				"@smithy/core": "^3.8.0",
+				"@smithy/eventstream-serde-browser": "^4.0.5",
+				"@smithy/eventstream-serde-config-resolver": "^4.1.3",
+				"@smithy/eventstream-serde-node": "^4.0.5",
+				"@smithy/fetch-http-handler": "^5.1.1",
+				"@smithy/hash-node": "^4.0.5",
+				"@smithy/invalid-dependency": "^4.0.5",
+				"@smithy/middleware-content-length": "^4.0.5",
+				"@smithy/middleware-endpoint": "^4.1.18",
+				"@smithy/middleware-retry": "^4.1.19",
+				"@smithy/middleware-serde": "^4.0.9",
+				"@smithy/middleware-stack": "^4.0.5",
+				"@smithy/node-config-provider": "^4.1.4",
+				"@smithy/node-http-handler": "^4.1.1",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/smithy-client": "^4.4.10",
+				"@smithy/types": "^4.3.2",
+				"@smithy/url-parser": "^4.0.5",
 				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-body-length-browser": "^4.0.0",
 				"@smithy/util-body-length-node": "^4.0.0",
-				"@smithy/util-defaults-mode-browser": "^4.0.7",
-				"@smithy/util-defaults-mode-node": "^4.0.7",
-				"@smithy/util-endpoints": "^3.0.1",
-				"@smithy/util-middleware": "^4.0.1",
-				"@smithy/util-retry": "^4.0.1",
-				"@smithy/util-stream": "^4.1.2",
+				"@smithy/util-defaults-mode-browser": "^4.0.26",
+				"@smithy/util-defaults-mode-node": "^4.0.26",
+				"@smithy/util-endpoints": "^3.0.7",
+				"@smithy/util-middleware": "^4.0.5",
+				"@smithy/util-retry": "^4.0.7",
+				"@smithy/util-stream": "^4.2.4",
 				"@smithy/util-utf8": "^4.0.0",
 				"@types/uuid": "^9.0.1",
 				"tslib": "^2.6.2",
@@ -33154,572 +33713,581 @@
 			},
 			"dependencies": {
 				"@aws-sdk/client-sso": {
-					"version": "3.758.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.758.0.tgz",
-					"integrity": "sha512-BoGO6IIWrLyLxQG6txJw6RT2urmbtlwfggapNCrNPyYjlXpzTSJhBYjndg7TpDATFd0SXL0zm8y/tXsUXNkdYQ==",
+					"version": "3.873.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.873.0.tgz",
+					"integrity": "sha512-EmcrOgFODWe7IsLKFTeSXM9TlQ80/BO1MBISlr7w2ydnOaUYIiPGRRJnDpeIgMaNqT4Rr2cRN2RiMrbFO7gDdA==",
 					"requires": {
 						"@aws-crypto/sha256-browser": "5.2.0",
 						"@aws-crypto/sha256-js": "5.2.0",
-						"@aws-sdk/core": "3.758.0",
-						"@aws-sdk/middleware-host-header": "3.734.0",
-						"@aws-sdk/middleware-logger": "3.734.0",
-						"@aws-sdk/middleware-recursion-detection": "3.734.0",
-						"@aws-sdk/middleware-user-agent": "3.758.0",
-						"@aws-sdk/region-config-resolver": "3.734.0",
-						"@aws-sdk/types": "3.734.0",
-						"@aws-sdk/util-endpoints": "3.743.0",
-						"@aws-sdk/util-user-agent-browser": "3.734.0",
-						"@aws-sdk/util-user-agent-node": "3.758.0",
-						"@smithy/config-resolver": "^4.0.1",
-						"@smithy/core": "^3.1.5",
-						"@smithy/fetch-http-handler": "^5.0.1",
-						"@smithy/hash-node": "^4.0.1",
-						"@smithy/invalid-dependency": "^4.0.1",
-						"@smithy/middleware-content-length": "^4.0.1",
-						"@smithy/middleware-endpoint": "^4.0.6",
-						"@smithy/middleware-retry": "^4.0.7",
-						"@smithy/middleware-serde": "^4.0.2",
-						"@smithy/middleware-stack": "^4.0.1",
-						"@smithy/node-config-provider": "^4.0.1",
-						"@smithy/node-http-handler": "^4.0.3",
-						"@smithy/protocol-http": "^5.0.1",
-						"@smithy/smithy-client": "^4.1.6",
-						"@smithy/types": "^4.1.0",
-						"@smithy/url-parser": "^4.0.1",
+						"@aws-sdk/core": "3.873.0",
+						"@aws-sdk/middleware-host-header": "3.873.0",
+						"@aws-sdk/middleware-logger": "3.873.0",
+						"@aws-sdk/middleware-recursion-detection": "3.873.0",
+						"@aws-sdk/middleware-user-agent": "3.873.0",
+						"@aws-sdk/region-config-resolver": "3.873.0",
+						"@aws-sdk/types": "3.862.0",
+						"@aws-sdk/util-endpoints": "3.873.0",
+						"@aws-sdk/util-user-agent-browser": "3.873.0",
+						"@aws-sdk/util-user-agent-node": "3.873.0",
+						"@smithy/config-resolver": "^4.1.5",
+						"@smithy/core": "^3.8.0",
+						"@smithy/fetch-http-handler": "^5.1.1",
+						"@smithy/hash-node": "^4.0.5",
+						"@smithy/invalid-dependency": "^4.0.5",
+						"@smithy/middleware-content-length": "^4.0.5",
+						"@smithy/middleware-endpoint": "^4.1.18",
+						"@smithy/middleware-retry": "^4.1.19",
+						"@smithy/middleware-serde": "^4.0.9",
+						"@smithy/middleware-stack": "^4.0.5",
+						"@smithy/node-config-provider": "^4.1.4",
+						"@smithy/node-http-handler": "^4.1.1",
+						"@smithy/protocol-http": "^5.1.3",
+						"@smithy/smithy-client": "^4.4.10",
+						"@smithy/types": "^4.3.2",
+						"@smithy/url-parser": "^4.0.5",
 						"@smithy/util-base64": "^4.0.0",
 						"@smithy/util-body-length-browser": "^4.0.0",
 						"@smithy/util-body-length-node": "^4.0.0",
-						"@smithy/util-defaults-mode-browser": "^4.0.7",
-						"@smithy/util-defaults-mode-node": "^4.0.7",
-						"@smithy/util-endpoints": "^3.0.1",
-						"@smithy/util-middleware": "^4.0.1",
-						"@smithy/util-retry": "^4.0.1",
+						"@smithy/util-defaults-mode-browser": "^4.0.26",
+						"@smithy/util-defaults-mode-node": "^4.0.26",
+						"@smithy/util-endpoints": "^3.0.7",
+						"@smithy/util-middleware": "^4.0.5",
+						"@smithy/util-retry": "^4.0.7",
 						"@smithy/util-utf8": "^4.0.0",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@aws-sdk/core": {
-					"version": "3.758.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.758.0.tgz",
-					"integrity": "sha512-0RswbdR9jt/XKemaLNuxi2gGr4xGlHyGxkTdhSQzCyUe9A9OPCoLl3rIESRguQEech+oJnbHk/wuiwHqTuP9sg==",
+					"version": "3.873.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.873.0.tgz",
+					"integrity": "sha512-WrROjp8X1VvmnZ4TBzwM7RF+EB3wRaY9kQJLXw+Aes0/3zRjUXvGIlseobGJMqMEGnM0YekD2F87UaVfot1xeQ==",
 					"requires": {
-						"@aws-sdk/types": "3.734.0",
-						"@smithy/core": "^3.1.5",
-						"@smithy/node-config-provider": "^4.0.1",
-						"@smithy/property-provider": "^4.0.1",
-						"@smithy/protocol-http": "^5.0.1",
-						"@smithy/signature-v4": "^5.0.1",
-						"@smithy/smithy-client": "^4.1.6",
-						"@smithy/types": "^4.1.0",
-						"@smithy/util-middleware": "^4.0.1",
-						"fast-xml-parser": "4.4.1",
+						"@aws-sdk/types": "3.862.0",
+						"@aws-sdk/xml-builder": "3.873.0",
+						"@smithy/core": "^3.8.0",
+						"@smithy/node-config-provider": "^4.1.4",
+						"@smithy/property-provider": "^4.0.5",
+						"@smithy/protocol-http": "^5.1.3",
+						"@smithy/signature-v4": "^5.1.3",
+						"@smithy/smithy-client": "^4.4.10",
+						"@smithy/types": "^4.3.2",
+						"@smithy/util-base64": "^4.0.0",
+						"@smithy/util-body-length-browser": "^4.0.0",
+						"@smithy/util-middleware": "^4.0.5",
+						"@smithy/util-utf8": "^4.0.0",
+						"fast-xml-parser": "5.2.5",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@aws-sdk/credential-provider-env": {
-					"version": "3.758.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.758.0.tgz",
-					"integrity": "sha512-N27eFoRrO6MeUNumtNHDW9WOiwfd59LPXPqDrIa3kWL/s+fOKFHb9xIcF++bAwtcZnAxKkgpDCUP+INNZskE+w==",
+					"version": "3.873.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.873.0.tgz",
+					"integrity": "sha512-FWj1yUs45VjCADv80JlGshAttUHBL2xtTAbJcAxkkJZzLRKVkdyrepFWhv/95MvDyzfbT6PgJiWMdW65l/8ooA==",
 					"requires": {
-						"@aws-sdk/core": "3.758.0",
-						"@aws-sdk/types": "3.734.0",
-						"@smithy/property-provider": "^4.0.1",
-						"@smithy/types": "^4.1.0",
+						"@aws-sdk/core": "3.873.0",
+						"@aws-sdk/types": "3.862.0",
+						"@smithy/property-provider": "^4.0.5",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@aws-sdk/credential-provider-http": {
-					"version": "3.758.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.758.0.tgz",
-					"integrity": "sha512-Xt9/U8qUCiw1hihztWkNeIR+arg6P+yda10OuCHX6kFVx3auTlU7+hCqs3UxqniGU4dguHuftf3mRpi5/GJ33Q==",
+					"version": "3.873.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.873.0.tgz",
+					"integrity": "sha512-0sIokBlXIsndjZFUfr3Xui8W6kPC4DAeBGAXxGi9qbFZ9PWJjn1vt2COLikKH3q2snchk+AsznREZG8NW6ezSg==",
 					"requires": {
-						"@aws-sdk/core": "3.758.0",
-						"@aws-sdk/types": "3.734.0",
-						"@smithy/fetch-http-handler": "^5.0.1",
-						"@smithy/node-http-handler": "^4.0.3",
-						"@smithy/property-provider": "^4.0.1",
-						"@smithy/protocol-http": "^5.0.1",
-						"@smithy/smithy-client": "^4.1.6",
-						"@smithy/types": "^4.1.0",
-						"@smithy/util-stream": "^4.1.2",
+						"@aws-sdk/core": "3.873.0",
+						"@aws-sdk/types": "3.862.0",
+						"@smithy/fetch-http-handler": "^5.1.1",
+						"@smithy/node-http-handler": "^4.1.1",
+						"@smithy/property-provider": "^4.0.5",
+						"@smithy/protocol-http": "^5.1.3",
+						"@smithy/smithy-client": "^4.4.10",
+						"@smithy/types": "^4.3.2",
+						"@smithy/util-stream": "^4.2.4",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@aws-sdk/credential-provider-ini": {
-					"version": "3.758.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.758.0.tgz",
-					"integrity": "sha512-cymSKMcP5d+OsgetoIZ5QCe1wnp2Q/tq+uIxVdh9MbfdBBEnl9Ecq6dH6VlYS89sp4QKuxHxkWXVnbXU3Q19Aw==",
+					"version": "3.873.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.873.0.tgz",
+					"integrity": "sha512-bQdGqh47Sk0+2S3C+N46aNQsZFzcHs7ndxYLARH/avYXf02Nl68p194eYFaAHJSQ1re5IbExU1+pbums7FJ9fA==",
 					"requires": {
-						"@aws-sdk/core": "3.758.0",
-						"@aws-sdk/credential-provider-env": "3.758.0",
-						"@aws-sdk/credential-provider-http": "3.758.0",
-						"@aws-sdk/credential-provider-process": "3.758.0",
-						"@aws-sdk/credential-provider-sso": "3.758.0",
-						"@aws-sdk/credential-provider-web-identity": "3.758.0",
-						"@aws-sdk/nested-clients": "3.758.0",
-						"@aws-sdk/types": "3.734.0",
-						"@smithy/credential-provider-imds": "^4.0.1",
-						"@smithy/property-provider": "^4.0.1",
-						"@smithy/shared-ini-file-loader": "^4.0.1",
-						"@smithy/types": "^4.1.0",
+						"@aws-sdk/core": "3.873.0",
+						"@aws-sdk/credential-provider-env": "3.873.0",
+						"@aws-sdk/credential-provider-http": "3.873.0",
+						"@aws-sdk/credential-provider-process": "3.873.0",
+						"@aws-sdk/credential-provider-sso": "3.873.0",
+						"@aws-sdk/credential-provider-web-identity": "3.873.0",
+						"@aws-sdk/nested-clients": "3.873.0",
+						"@aws-sdk/types": "3.862.0",
+						"@smithy/credential-provider-imds": "^4.0.7",
+						"@smithy/property-provider": "^4.0.5",
+						"@smithy/shared-ini-file-loader": "^4.0.5",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@aws-sdk/credential-provider-node": {
-					"version": "3.758.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.758.0.tgz",
-					"integrity": "sha512-+DaMv63wiq7pJrhIQzZYMn4hSarKiizDoJRvyR7WGhnn0oQ/getX9Z0VNCV3i7lIFoLNTb7WMmQ9k7+z/uD5EQ==",
+					"version": "3.873.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.873.0.tgz",
+					"integrity": "sha512-+v/xBEB02k2ExnSDL8+1gD6UizY4Q/HaIJkNSkitFynRiiTQpVOSkCkA0iWxzksMeN8k1IHTE5gzeWpkEjNwbA==",
 					"requires": {
-						"@aws-sdk/credential-provider-env": "3.758.0",
-						"@aws-sdk/credential-provider-http": "3.758.0",
-						"@aws-sdk/credential-provider-ini": "3.758.0",
-						"@aws-sdk/credential-provider-process": "3.758.0",
-						"@aws-sdk/credential-provider-sso": "3.758.0",
-						"@aws-sdk/credential-provider-web-identity": "3.758.0",
-						"@aws-sdk/types": "3.734.0",
-						"@smithy/credential-provider-imds": "^4.0.1",
-						"@smithy/property-provider": "^4.0.1",
-						"@smithy/shared-ini-file-loader": "^4.0.1",
-						"@smithy/types": "^4.1.0",
+						"@aws-sdk/credential-provider-env": "3.873.0",
+						"@aws-sdk/credential-provider-http": "3.873.0",
+						"@aws-sdk/credential-provider-ini": "3.873.0",
+						"@aws-sdk/credential-provider-process": "3.873.0",
+						"@aws-sdk/credential-provider-sso": "3.873.0",
+						"@aws-sdk/credential-provider-web-identity": "3.873.0",
+						"@aws-sdk/types": "3.862.0",
+						"@smithy/credential-provider-imds": "^4.0.7",
+						"@smithy/property-provider": "^4.0.5",
+						"@smithy/shared-ini-file-loader": "^4.0.5",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@aws-sdk/credential-provider-process": {
-					"version": "3.758.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.758.0.tgz",
-					"integrity": "sha512-AzcY74QTPqcbXWVgjpPZ3HOmxQZYPROIBz2YINF0OQk0MhezDWV/O7Xec+K1+MPGQO3qS6EDrUUlnPLjsqieHA==",
+					"version": "3.873.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.873.0.tgz",
+					"integrity": "sha512-ycFv9WN+UJF7bK/ElBq1ugWA4NMbYS//1K55bPQZb2XUpAM2TWFlEjG7DIyOhLNTdl6+CbHlCdhlKQuDGgmm0A==",
 					"requires": {
-						"@aws-sdk/core": "3.758.0",
-						"@aws-sdk/types": "3.734.0",
-						"@smithy/property-provider": "^4.0.1",
-						"@smithy/shared-ini-file-loader": "^4.0.1",
-						"@smithy/types": "^4.1.0",
+						"@aws-sdk/core": "3.873.0",
+						"@aws-sdk/types": "3.862.0",
+						"@smithy/property-provider": "^4.0.5",
+						"@smithy/shared-ini-file-loader": "^4.0.5",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@aws-sdk/credential-provider-sso": {
-					"version": "3.758.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.758.0.tgz",
-					"integrity": "sha512-x0FYJqcOLUCv8GLLFDYMXRAQKGjoM+L0BG4BiHYZRDf24yQWFCAZsCQAYKo6XZYh2qznbsW6f//qpyJ5b0QVKQ==",
+					"version": "3.873.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.873.0.tgz",
+					"integrity": "sha512-SudkAOZmjEEYgUrqlUUjvrtbWJeI54/0Xo87KRxm4kfBtMqSx0TxbplNUAk8Gkg4XQNY0o7jpG8tK7r2Wc2+uw==",
 					"requires": {
-						"@aws-sdk/client-sso": "3.758.0",
-						"@aws-sdk/core": "3.758.0",
-						"@aws-sdk/token-providers": "3.758.0",
-						"@aws-sdk/types": "3.734.0",
-						"@smithy/property-provider": "^4.0.1",
-						"@smithy/shared-ini-file-loader": "^4.0.1",
-						"@smithy/types": "^4.1.0",
+						"@aws-sdk/client-sso": "3.873.0",
+						"@aws-sdk/core": "3.873.0",
+						"@aws-sdk/token-providers": "3.873.0",
+						"@aws-sdk/types": "3.862.0",
+						"@smithy/property-provider": "^4.0.5",
+						"@smithy/shared-ini-file-loader": "^4.0.5",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@aws-sdk/credential-provider-web-identity": {
-					"version": "3.758.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.758.0.tgz",
-					"integrity": "sha512-XGguXhBqiCXMXRxcfCAVPlMbm3VyJTou79r/3mxWddHWF0XbhaQiBIbUz6vobVTD25YQRbWSmSch7VA8kI5Lrw==",
+					"version": "3.873.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.873.0.tgz",
+					"integrity": "sha512-Gw2H21+VkA6AgwKkBtTtlGZ45qgyRZPSKWs0kUwXVlmGOiPz61t/lBX0vG6I06ZIz2wqeTJ5OA1pWZLqw1j0JQ==",
 					"requires": {
-						"@aws-sdk/core": "3.758.0",
-						"@aws-sdk/nested-clients": "3.758.0",
-						"@aws-sdk/types": "3.734.0",
-						"@smithy/property-provider": "^4.0.1",
-						"@smithy/types": "^4.1.0",
+						"@aws-sdk/core": "3.873.0",
+						"@aws-sdk/nested-clients": "3.873.0",
+						"@aws-sdk/types": "3.862.0",
+						"@smithy/property-provider": "^4.0.5",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@aws-sdk/middleware-host-header": {
-					"version": "3.734.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.734.0.tgz",
-					"integrity": "sha512-LW7RRgSOHHBzWZnigNsDIzu3AiwtjeI2X66v+Wn1P1u+eXssy1+up4ZY/h+t2sU4LU36UvEf+jrZti9c6vRnFw==",
+					"version": "3.873.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.873.0.tgz",
+					"integrity": "sha512-KZ/W1uruWtMOs7D5j3KquOxzCnV79KQW9MjJFZM/M0l6KI8J6V3718MXxFHsTjUE4fpdV6SeCNLV1lwGygsjJA==",
 					"requires": {
-						"@aws-sdk/types": "3.734.0",
-						"@smithy/protocol-http": "^5.0.1",
-						"@smithy/types": "^4.1.0",
+						"@aws-sdk/types": "3.862.0",
+						"@smithy/protocol-http": "^5.1.3",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@aws-sdk/middleware-logger": {
-					"version": "3.734.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.734.0.tgz",
-					"integrity": "sha512-mUMFITpJUW3LcKvFok176eI5zXAUomVtahb9IQBwLzkqFYOrMJvWAvoV4yuxrJ8TlQBG8gyEnkb9SnhZvjg67w==",
+					"version": "3.873.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.873.0.tgz",
+					"integrity": "sha512-QhNZ8X7pW68kFez9QxUSN65Um0Feo18ZmHxszQZNUhKDsXew/EG9NPQE/HgYcekcon35zHxC4xs+FeNuPurP2g==",
 					"requires": {
-						"@aws-sdk/types": "3.734.0",
-						"@smithy/types": "^4.1.0",
+						"@aws-sdk/types": "3.862.0",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@aws-sdk/middleware-recursion-detection": {
-					"version": "3.734.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.734.0.tgz",
-					"integrity": "sha512-CUat2d9ITsFc2XsmeiRQO96iWpxSKYFjxvj27Hc7vo87YUHRnfMfnc8jw1EpxEwMcvBD7LsRa6vDNky6AjcrFA==",
+					"version": "3.873.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.873.0.tgz",
+					"integrity": "sha512-OtgY8EXOzRdEWR//WfPkA/fXl0+WwE8hq0y9iw2caNyKPtca85dzrrZWnPqyBK/cpImosrpR1iKMYr41XshsCg==",
 					"requires": {
-						"@aws-sdk/types": "3.734.0",
-						"@smithy/protocol-http": "^5.0.1",
-						"@smithy/types": "^4.1.0",
+						"@aws-sdk/types": "3.862.0",
+						"@smithy/protocol-http": "^5.1.3",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@aws-sdk/middleware-user-agent": {
-					"version": "3.758.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.758.0.tgz",
-					"integrity": "sha512-iNyehQXtQlj69JCgfaOssgZD4HeYGOwxcaKeG6F+40cwBjTAi0+Ph1yfDwqk2qiBPIRWJ/9l2LodZbxiBqgrwg==",
+					"version": "3.873.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.873.0.tgz",
+					"integrity": "sha512-gHqAMYpWkPhZLwqB3Yj83JKdL2Vsb64sryo8LN2UdpElpS+0fT4yjqSxKTfp7gkhN6TCIxF24HQgbPk5FMYJWw==",
 					"requires": {
-						"@aws-sdk/core": "3.758.0",
-						"@aws-sdk/types": "3.734.0",
-						"@aws-sdk/util-endpoints": "3.743.0",
-						"@smithy/core": "^3.1.5",
-						"@smithy/protocol-http": "^5.0.1",
-						"@smithy/types": "^4.1.0",
+						"@aws-sdk/core": "3.873.0",
+						"@aws-sdk/types": "3.862.0",
+						"@aws-sdk/util-endpoints": "3.873.0",
+						"@smithy/core": "^3.8.0",
+						"@smithy/protocol-http": "^5.1.3",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@aws-sdk/region-config-resolver": {
-					"version": "3.734.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.734.0.tgz",
-					"integrity": "sha512-Lvj1kPRC5IuJBr9DyJ9T9/plkh+EfKLy+12s/mykOy1JaKHDpvj+XGy2YO6YgYVOb8JFtaqloid+5COtje4JTQ==",
+					"version": "3.873.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.873.0.tgz",
+					"integrity": "sha512-q9sPoef+BBG6PJnc4x60vK/bfVwvRWsPgcoQyIra057S/QGjq5VkjvNk6H8xedf6vnKlXNBwq9BaANBXnldUJg==",
 					"requires": {
-						"@aws-sdk/types": "3.734.0",
-						"@smithy/node-config-provider": "^4.0.1",
-						"@smithy/types": "^4.1.0",
+						"@aws-sdk/types": "3.862.0",
+						"@smithy/node-config-provider": "^4.1.4",
+						"@smithy/types": "^4.3.2",
 						"@smithy/util-config-provider": "^4.0.0",
-						"@smithy/util-middleware": "^4.0.1",
+						"@smithy/util-middleware": "^4.0.5",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@aws-sdk/token-providers": {
-					"version": "3.758.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.758.0.tgz",
-					"integrity": "sha512-ckptN1tNrIfQUaGWm/ayW1ddG+imbKN7HHhjFdS4VfItsP0QQOB0+Ov+tpgb4MoNR4JaUghMIVStjIeHN2ks1w==",
+					"version": "3.873.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.873.0.tgz",
+					"integrity": "sha512-BWOCeFeV/Ba8fVhtwUw/0Hz4wMm9fjXnMb4Z2a5he/jFlz5mt1/rr6IQ4MyKgzOaz24YrvqsJW2a0VUKOaYDvg==",
 					"requires": {
-						"@aws-sdk/nested-clients": "3.758.0",
-						"@aws-sdk/types": "3.734.0",
-						"@smithy/property-provider": "^4.0.1",
-						"@smithy/shared-ini-file-loader": "^4.0.1",
-						"@smithy/types": "^4.1.0",
+						"@aws-sdk/core": "3.873.0",
+						"@aws-sdk/nested-clients": "3.873.0",
+						"@aws-sdk/types": "3.862.0",
+						"@smithy/property-provider": "^4.0.5",
+						"@smithy/shared-ini-file-loader": "^4.0.5",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@aws-sdk/types": {
-					"version": "3.734.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.734.0.tgz",
-					"integrity": "sha512-o11tSPTT70nAkGV1fN9wm/hAIiLPyWX6SuGf+9JyTp7S/rC2cFWhR26MvA69nplcjNaXVzB0f+QFrLXXjOqCrg==",
+					"version": "3.862.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.862.0.tgz",
+					"integrity": "sha512-Bei+RL0cDxxV+lW2UezLbCYYNeJm6Nzee0TpW0FfyTRBhH9C1XQh4+x+IClriXvgBnRquTMMYsmJfvx8iyLKrg==",
 					"requires": {
-						"@smithy/types": "^4.1.0",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@aws-sdk/util-endpoints": {
-					"version": "3.743.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.743.0.tgz",
-					"integrity": "sha512-sN1l559zrixeh5x+pttrnd0A3+r34r0tmPkJ/eaaMaAzXqsmKU/xYre9K3FNnsSS1J1k4PEfk/nHDTVUgFYjnw==",
+					"version": "3.873.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.873.0.tgz",
+					"integrity": "sha512-YByHrhjxYdjKRf/RQygRK1uh0As1FIi9+jXTcIEX/rBgN8mUByczr2u4QXBzw7ZdbdcOBMOkPnLRjNOWW1MkFg==",
 					"requires": {
-						"@aws-sdk/types": "3.734.0",
-						"@smithy/types": "^4.1.0",
-						"@smithy/util-endpoints": "^3.0.1",
+						"@aws-sdk/types": "3.862.0",
+						"@smithy/types": "^4.3.2",
+						"@smithy/url-parser": "^4.0.5",
+						"@smithy/util-endpoints": "^3.0.7",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@aws-sdk/util-user-agent-browser": {
-					"version": "3.734.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.734.0.tgz",
-					"integrity": "sha512-xQTCus6Q9LwUuALW+S76OL0jcWtMOVu14q+GoLnWPUM7QeUw963oQcLhF7oq0CtaLLKyl4GOUfcwc773Zmwwng==",
+					"version": "3.873.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.873.0.tgz",
+					"integrity": "sha512-AcRdbK6o19yehEcywI43blIBhOCSo6UgyWcuOJX5CFF8k39xm1ILCjQlRRjchLAxWrm0lU0Q7XV90RiMMFMZtA==",
 					"requires": {
-						"@aws-sdk/types": "3.734.0",
-						"@smithy/types": "^4.1.0",
+						"@aws-sdk/types": "3.862.0",
+						"@smithy/types": "^4.3.2",
 						"bowser": "^2.11.0",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@aws-sdk/util-user-agent-node": {
-					"version": "3.758.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.758.0.tgz",
-					"integrity": "sha512-A5EZw85V6WhoKMV2hbuFRvb9NPlxEErb4HPO6/SPXYY4QrjprIzScHxikqcWv1w4J3apB1wto9LPU3IMsYtfrw==",
+					"version": "3.873.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.873.0.tgz",
+					"integrity": "sha512-9MivTP+q9Sis71UxuBaIY3h5jxH0vN3/ZWGxO8ADL19S2OIfknrYSAfzE5fpoKROVBu0bS4VifHOFq4PY1zsxw==",
 					"requires": {
-						"@aws-sdk/middleware-user-agent": "3.758.0",
-						"@aws-sdk/types": "3.734.0",
-						"@smithy/node-config-provider": "^4.0.1",
-						"@smithy/types": "^4.1.0",
+						"@aws-sdk/middleware-user-agent": "3.873.0",
+						"@aws-sdk/types": "3.862.0",
+						"@smithy/node-config-provider": "^4.1.4",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/abort-controller": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
-					"integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.5.tgz",
+					"integrity": "sha512-jcrqdTQurIrBbUm4W2YdLVMQDoL0sA9DTxYd2s+R/y+2U9NLOP7Xf/YqfSg1FZhlZIYEnvk2mwbyvIfdLEPo8g==",
 					"requires": {
-						"@smithy/types": "^4.1.0",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/config-resolver": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.0.1.tgz",
-					"integrity": "sha512-Igfg8lKu3dRVkTSEm98QpZUvKEOa71jDX4vKRcvJVyRc3UgN3j7vFMf0s7xLQhYmKa8kyJGQgUJDOV5V3neVlQ==",
+					"version": "4.1.5",
+					"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.5.tgz",
+					"integrity": "sha512-viuHMxBAqydkB0AfWwHIdwf/PRH2z5KHGUzqyRtS/Wv+n3IHI993Sk76VCA7dD/+GzgGOmlJDITfPcJC1nIVIw==",
 					"requires": {
-						"@smithy/node-config-provider": "^4.0.1",
-						"@smithy/types": "^4.1.0",
+						"@smithy/node-config-provider": "^4.1.4",
+						"@smithy/types": "^4.3.2",
 						"@smithy/util-config-provider": "^4.0.0",
-						"@smithy/util-middleware": "^4.0.1",
+						"@smithy/util-middleware": "^4.0.5",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/core": {
-					"version": "3.1.5",
-					"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.5.tgz",
-					"integrity": "sha512-HLclGWPkCsekQgsyzxLhCQLa8THWXtB5PxyYN+2O6nkyLt550KQKTlbV2D1/j5dNIQapAZM1+qFnpBFxZQkgCA==",
+					"version": "3.8.0",
+					"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.8.0.tgz",
+					"integrity": "sha512-EYqsIYJmkR1VhVE9pccnk353xhs+lB6btdutJEtsp7R055haMJp2yE16eSxw8fv+G0WUY6vqxyYOP8kOqawxYQ==",
 					"requires": {
-						"@smithy/middleware-serde": "^4.0.2",
-						"@smithy/protocol-http": "^5.0.1",
-						"@smithy/types": "^4.1.0",
+						"@smithy/middleware-serde": "^4.0.9",
+						"@smithy/protocol-http": "^5.1.3",
+						"@smithy/types": "^4.3.2",
+						"@smithy/util-base64": "^4.0.0",
 						"@smithy/util-body-length-browser": "^4.0.0",
-						"@smithy/util-middleware": "^4.0.1",
-						"@smithy/util-stream": "^4.1.2",
+						"@smithy/util-middleware": "^4.0.5",
+						"@smithy/util-stream": "^4.2.4",
 						"@smithy/util-utf8": "^4.0.0",
-						"tslib": "^2.6.2"
+						"@types/uuid": "^9.0.1",
+						"tslib": "^2.6.2",
+						"uuid": "^9.0.1"
 					}
 				},
 				"@smithy/credential-provider-imds": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.1.tgz",
-					"integrity": "sha512-l/qdInaDq1Zpznpmev/+52QomsJNZ3JkTl5yrTl02V6NBgJOQ4LY0SFw/8zsMwj3tLe8vqiIuwF6nxaEwgf6mg==",
+					"version": "4.0.7",
+					"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.7.tgz",
+					"integrity": "sha512-dDzrMXA8d8riFNiPvytxn0mNwR4B3h8lgrQ5UjAGu6T9z/kRg/Xncf4tEQHE/+t25sY8IH3CowcmWi+1U5B1Gw==",
 					"requires": {
-						"@smithy/node-config-provider": "^4.0.1",
-						"@smithy/property-provider": "^4.0.1",
-						"@smithy/types": "^4.1.0",
-						"@smithy/url-parser": "^4.0.1",
+						"@smithy/node-config-provider": "^4.1.4",
+						"@smithy/property-provider": "^4.0.5",
+						"@smithy/types": "^4.3.2",
+						"@smithy/url-parser": "^4.0.5",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/eventstream-serde-node": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.0.1.tgz",
-					"integrity": "sha512-o4CoOI6oYGYJ4zXo34U8X9szDe3oGjmHgsMGiZM0j4vtNoT+h80TLnkUcrLZR3+E6HIxqW+G+9WHAVfl0GXK0Q==",
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.0.5.tgz",
+					"integrity": "sha512-lGS10urI4CNzz6YlTe5EYG0YOpsSp3ra8MXyco4aqSkQDuyZPIw2hcaxDU82OUVtK7UY9hrSvgWtpsW5D4rb4g==",
 					"requires": {
-						"@smithy/eventstream-serde-universal": "^4.0.1",
-						"@smithy/types": "^4.1.0",
+						"@smithy/eventstream-serde-universal": "^4.0.5",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/fetch-http-handler": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.1.tgz",
-					"integrity": "sha512-3aS+fP28urrMW2KTjb6z9iFow6jO8n3MFfineGbndvzGZit3taZhKWtTorf+Gp5RpFDDafeHlhfsGlDCXvUnJA==",
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.1.1.tgz",
+					"integrity": "sha512-61WjM0PWmZJR+SnmzaKI7t7G0UkkNFboDpzIdzSoy7TByUzlxo18Qlh9s71qug4AY4hlH/CwXdubMtkcNEb/sQ==",
 					"requires": {
-						"@smithy/protocol-http": "^5.0.1",
-						"@smithy/querystring-builder": "^4.0.1",
-						"@smithy/types": "^4.1.0",
+						"@smithy/protocol-http": "^5.1.3",
+						"@smithy/querystring-builder": "^4.0.5",
+						"@smithy/types": "^4.3.2",
 						"@smithy/util-base64": "^4.0.0",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/hash-node": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.1.tgz",
-					"integrity": "sha512-TJ6oZS+3r2Xu4emVse1YPB3Dq3d8RkZDKcPr71Nj/lJsdAP1c7oFzYqEn1IBc915TsgLl2xIJNuxCz+gLbLE0w==",
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.5.tgz",
+					"integrity": "sha512-cv1HHkKhpyRb6ahD8Vcfb2Hgz67vNIXEp2vnhzfxLFGRukLCNEA5QdsorbUEzXma1Rco0u3rx5VTqbM06GcZqQ==",
 					"requires": {
-						"@smithy/types": "^4.1.0",
+						"@smithy/types": "^4.3.2",
 						"@smithy/util-buffer-from": "^4.0.0",
 						"@smithy/util-utf8": "^4.0.0",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/invalid-dependency": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.1.tgz",
-					"integrity": "sha512-gdudFPf4QRQ5pzj7HEnu6FhKRi61BfH/Gk5Yf6O0KiSbr1LlVhgjThcvjdu658VE6Nve8vaIWB8/fodmS1rBPQ==",
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.5.tgz",
+					"integrity": "sha512-IVnb78Qtf7EJpoEVo7qJ8BEXQwgC4n3igeJNNKEj/MLYtapnx8A67Zt/J3RXAj2xSO1910zk0LdFiygSemuLow==",
 					"requires": {
-						"@smithy/types": "^4.1.0",
+						"@smithy/types": "^4.3.2",
+						"tslib": "^2.6.2"
+					}
+				},
+				"@smithy/is-array-buffer": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+					"integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+					"requires": {
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/middleware-content-length": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.1.tgz",
-					"integrity": "sha512-OGXo7w5EkB5pPiac7KNzVtfCW2vKBTZNuCctn++TTSOMpe6RZO/n6WEC1AxJINn3+vWLKW49uad3lo/u0WJ9oQ==",
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.5.tgz",
+					"integrity": "sha512-l1jlNZoYzoCC7p0zCtBDE5OBXZ95yMKlRlftooE5jPWQn4YBPLgsp+oeHp7iMHaTGoUdFqmHOPa8c9G3gBsRpQ==",
 					"requires": {
-						"@smithy/protocol-http": "^5.0.1",
-						"@smithy/types": "^4.1.0",
+						"@smithy/protocol-http": "^5.1.3",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/middleware-endpoint": {
-					"version": "4.0.6",
-					"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.6.tgz",
-					"integrity": "sha512-ftpmkTHIFqgaFugcjzLZv3kzPEFsBFSnq1JsIkr2mwFzCraZVhQk2gqN51OOeRxqhbPTkRFj39Qd2V91E/mQxg==",
+					"version": "4.1.18",
+					"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.18.tgz",
+					"integrity": "sha512-ZhvqcVRPZxnZlokcPaTwb+r+h4yOIOCJmx0v2d1bpVlmP465g3qpVSf7wxcq5zZdu4jb0H4yIMxuPwDJSQc3MQ==",
 					"requires": {
-						"@smithy/core": "^3.1.5",
-						"@smithy/middleware-serde": "^4.0.2",
-						"@smithy/node-config-provider": "^4.0.1",
-						"@smithy/shared-ini-file-loader": "^4.0.1",
-						"@smithy/types": "^4.1.0",
-						"@smithy/url-parser": "^4.0.1",
-						"@smithy/util-middleware": "^4.0.1",
+						"@smithy/core": "^3.8.0",
+						"@smithy/middleware-serde": "^4.0.9",
+						"@smithy/node-config-provider": "^4.1.4",
+						"@smithy/shared-ini-file-loader": "^4.0.5",
+						"@smithy/types": "^4.3.2",
+						"@smithy/url-parser": "^4.0.5",
+						"@smithy/util-middleware": "^4.0.5",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/middleware-retry": {
-					"version": "4.0.7",
-					"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.0.7.tgz",
-					"integrity": "sha512-58j9XbUPLkqAcV1kHzVX/kAR16GT+j7DUZJqwzsxh1jtz7G82caZiGyyFgUvogVfNTg3TeAOIJepGc8TXF4AVQ==",
+					"version": "4.1.19",
+					"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.19.tgz",
+					"integrity": "sha512-X58zx/NVECjeuUB6A8HBu4bhx72EoUz+T5jTMIyeNKx2lf+Gs9TmWPNNkH+5QF0COjpInP/xSpJGJ7xEnAklQQ==",
 					"requires": {
-						"@smithy/node-config-provider": "^4.0.1",
-						"@smithy/protocol-http": "^5.0.1",
-						"@smithy/service-error-classification": "^4.0.1",
-						"@smithy/smithy-client": "^4.1.6",
-						"@smithy/types": "^4.1.0",
-						"@smithy/util-middleware": "^4.0.1",
-						"@smithy/util-retry": "^4.0.1",
+						"@smithy/node-config-provider": "^4.1.4",
+						"@smithy/protocol-http": "^5.1.3",
+						"@smithy/service-error-classification": "^4.0.7",
+						"@smithy/smithy-client": "^4.4.10",
+						"@smithy/types": "^4.3.2",
+						"@smithy/util-middleware": "^4.0.5",
+						"@smithy/util-retry": "^4.0.7",
+						"@types/uuid": "^9.0.1",
 						"tslib": "^2.6.2",
 						"uuid": "^9.0.1"
 					}
 				},
 				"@smithy/middleware-serde": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.2.tgz",
-					"integrity": "sha512-Sdr5lOagCn5tt+zKsaW+U2/iwr6bI9p08wOkCp6/eL6iMbgdtc2R5Ety66rf87PeohR0ExI84Txz9GYv5ou3iQ==",
+					"version": "4.0.9",
+					"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.9.tgz",
+					"integrity": "sha512-uAFFR4dpeoJPGz8x9mhxp+RPjo5wW0QEEIPPPbLXiRRWeCATf/Km3gKIVR5vaP8bN1kgsPhcEeh+IZvUlBv6Xg==",
 					"requires": {
-						"@smithy/types": "^4.1.0",
+						"@smithy/protocol-http": "^5.1.3",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/middleware-stack": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
-					"integrity": "sha512-dHwDmrtR/ln8UTHpaIavRSzeIk5+YZTBtLnKwDW3G2t6nAupCiQUvNzNoHBpik63fwUaJPtlnMzXbQrNFWssIA==",
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.5.tgz",
+					"integrity": "sha512-/yoHDXZPh3ocRVyeWQFvC44u8seu3eYzZRveCMfgMOBcNKnAmOvjbL9+Cp5XKSIi9iYA9PECUuW2teDAk8T+OQ==",
 					"requires": {
-						"@smithy/types": "^4.1.0",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/node-config-provider": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
-					"integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
+					"version": "4.1.4",
+					"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.4.tgz",
+					"integrity": "sha512-+UDQV/k42jLEPPHSn39l0Bmc4sB1xtdI9Gd47fzo/0PbXzJ7ylgaOByVjF5EeQIumkepnrJyfx86dPa9p47Y+w==",
 					"requires": {
-						"@smithy/property-provider": "^4.0.1",
-						"@smithy/shared-ini-file-loader": "^4.0.1",
-						"@smithy/types": "^4.1.0",
+						"@smithy/property-provider": "^4.0.5",
+						"@smithy/shared-ini-file-loader": "^4.0.5",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/node-http-handler": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.3.tgz",
-					"integrity": "sha512-dYCLeINNbYdvmMLtW0VdhW1biXt+PPCGazzT5ZjKw46mOtdgToQEwjqZSS9/EN8+tNs/RO0cEWG044+YZs97aA==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.1.1.tgz",
+					"integrity": "sha512-RHnlHqFpoVdjSPPiYy/t40Zovf3BBHc2oemgD7VsVTFFZrU5erFFe0n52OANZZ/5sbshgD93sOh5r6I35Xmpaw==",
 					"requires": {
-						"@smithy/abort-controller": "^4.0.1",
-						"@smithy/protocol-http": "^5.0.1",
-						"@smithy/querystring-builder": "^4.0.1",
-						"@smithy/types": "^4.1.0",
+						"@smithy/abort-controller": "^4.0.5",
+						"@smithy/protocol-http": "^5.1.3",
+						"@smithy/querystring-builder": "^4.0.5",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/property-provider": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
-					"integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.5.tgz",
+					"integrity": "sha512-R/bswf59T/n9ZgfgUICAZoWYKBHcsVDurAGX88zsiUtOTA/xUAPyiT+qkNCPwFn43pZqN84M4MiUsbSGQmgFIQ==",
 					"requires": {
-						"@smithy/types": "^4.1.0",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/protocol-http": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
-					"integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
+					"version": "5.1.3",
+					"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.3.tgz",
+					"integrity": "sha512-fCJd2ZR7D22XhDY0l+92pUag/7je2BztPRQ01gU5bMChcyI0rlly7QFibnYHzcxDvccMjlpM/Q1ev8ceRIb48w==",
 					"requires": {
-						"@smithy/types": "^4.1.0",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/querystring-builder": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.1.tgz",
-					"integrity": "sha512-wU87iWZoCbcqrwszsOewEIuq+SU2mSoBE2CcsLwE0I19m0B2gOJr1MVjxWcDQYOzHbR1xCk7AcOBbGFUYOKvdg==",
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.5.tgz",
+					"integrity": "sha512-NJeSCU57piZ56c+/wY+AbAw6rxCCAOZLCIniRE7wqvndqxcKKDOXzwWjrY7wGKEISfhL9gBbAaWWgHsUGedk+A==",
 					"requires": {
-						"@smithy/types": "^4.1.0",
+						"@smithy/types": "^4.3.2",
 						"@smithy/util-uri-escape": "^4.0.0",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/querystring-parser": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.1.tgz",
-					"integrity": "sha512-Ma2XC7VS9aV77+clSFylVUnPZRindhB7BbmYiNOdr+CHt/kZNJoPP0cd3QxCnCFyPXC4eybmyE98phEHkqZ5Jw==",
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.5.tgz",
+					"integrity": "sha512-6SV7md2CzNG/WUeTjVe6Dj8noH32r4MnUeFKZrnVYsQxpGSIcphAanQMayi8jJLZAWm6pdM9ZXvKCpWOsIGg0w==",
 					"requires": {
-						"@smithy/types": "^4.1.0",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/service-error-classification": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.1.tgz",
-					"integrity": "sha512-3JNjBfOWpj/mYfjXJHB4Txc/7E4LVq32bwzE7m28GN79+M1f76XHflUaSUkhOriprPDzev9cX/M+dEB80DNDKA==",
+					"version": "4.0.7",
+					"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.7.tgz",
+					"integrity": "sha512-XvRHOipqpwNhEjDf2L5gJowZEm5nsxC16pAZOeEcsygdjv9A2jdOh3YoDQvOXBGTsaJk6mNWtzWalOB9976Wlg==",
 					"requires": {
-						"@smithy/types": "^4.1.0"
+						"@smithy/types": "^4.3.2"
 					}
 				},
 				"@smithy/shared-ini-file-loader": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
-					"integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.5.tgz",
+					"integrity": "sha512-YVVwehRDuehgoXdEL4r1tAAzdaDgaC9EQvhK0lEbfnbrd0bd5+CTQumbdPryX3J2shT7ZqQE+jPW4lmNBAB8JQ==",
 					"requires": {
-						"@smithy/types": "^4.1.0",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/signature-v4": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
-					"integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
+					"version": "5.1.3",
+					"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.3.tgz",
+					"integrity": "sha512-mARDSXSEgllNzMw6N+mC+r1AQlEBO3meEAkR/UlfAgnMzJUB3goRBWgip1EAMG99wh36MDqzo86SfIX5Y+VEaw==",
 					"requires": {
 						"@smithy/is-array-buffer": "^4.0.0",
-						"@smithy/protocol-http": "^5.0.1",
-						"@smithy/types": "^4.1.0",
+						"@smithy/protocol-http": "^5.1.3",
+						"@smithy/types": "^4.3.2",
 						"@smithy/util-hex-encoding": "^4.0.0",
-						"@smithy/util-middleware": "^4.0.1",
+						"@smithy/util-middleware": "^4.0.5",
 						"@smithy/util-uri-escape": "^4.0.0",
 						"@smithy/util-utf8": "^4.0.0",
 						"tslib": "^2.6.2"
-					},
-					"dependencies": {
-						"@smithy/is-array-buffer": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
-							"integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
-							"requires": {
-								"tslib": "^2.6.2"
-							}
-						}
 					}
 				},
 				"@smithy/smithy-client": {
-					"version": "4.1.6",
-					"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.6.tgz",
-					"integrity": "sha512-UYDolNg6h2O0L+cJjtgSyKKvEKCOa/8FHYJnBobyeoeWDmNpXjwOAtw16ezyeu1ETuuLEOZbrynK0ZY1Lx9Jbw==",
+					"version": "4.4.10",
+					"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.10.tgz",
+					"integrity": "sha512-iW6HjXqN0oPtRS0NK/zzZ4zZeGESIFcxj2FkWed3mcK8jdSdHzvnCKXSjvewESKAgGKAbJRA+OsaqKhkdYRbQQ==",
 					"requires": {
-						"@smithy/core": "^3.1.5",
-						"@smithy/middleware-endpoint": "^4.0.6",
-						"@smithy/middleware-stack": "^4.0.1",
-						"@smithy/protocol-http": "^5.0.1",
-						"@smithy/types": "^4.1.0",
-						"@smithy/util-stream": "^4.1.2",
+						"@smithy/core": "^3.8.0",
+						"@smithy/middleware-endpoint": "^4.1.18",
+						"@smithy/middleware-stack": "^4.0.5",
+						"@smithy/protocol-http": "^5.1.3",
+						"@smithy/types": "^4.3.2",
+						"@smithy/util-stream": "^4.2.4",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/types": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
-					"integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
+					"integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
 					"requires": {
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/url-parser": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
-					"integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.5.tgz",
+					"integrity": "sha512-j+733Um7f1/DXjYhCbvNXABV53NyCRRA54C7bNEIxNPs0YjfRxeMKjjgm2jvTYrciZyCjsicHwQ6Q0ylo+NAUw==",
 					"requires": {
-						"@smithy/querystring-parser": "^4.0.1",
-						"@smithy/types": "^4.1.0",
+						"@smithy/querystring-parser": "^4.0.5",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
@@ -33756,16 +34324,6 @@
 					"requires": {
 						"@smithy/is-array-buffer": "^4.0.0",
 						"tslib": "^2.6.2"
-					},
-					"dependencies": {
-						"@smithy/is-array-buffer": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
-							"integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
-							"requires": {
-								"tslib": "^2.6.2"
-							}
-						}
 					}
 				},
 				"@smithy/util-config-provider": {
@@ -33777,38 +34335,38 @@
 					}
 				},
 				"@smithy/util-defaults-mode-browser": {
-					"version": "4.0.7",
-					"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.7.tgz",
-					"integrity": "sha512-CZgDDrYHLv0RUElOsmZtAnp1pIjwDVCSuZWOPhIOBvG36RDfX1Q9+6lS61xBf+qqvHoqRjHxgINeQz47cYFC2Q==",
+					"version": "4.0.26",
+					"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.26.tgz",
+					"integrity": "sha512-xgl75aHIS/3rrGp7iTxQAOELYeyiwBu+eEgAk4xfKwJJ0L8VUjhO2shsDpeil54BOFsqmk5xfdesiewbUY5tKQ==",
 					"requires": {
-						"@smithy/property-provider": "^4.0.1",
-						"@smithy/smithy-client": "^4.1.6",
-						"@smithy/types": "^4.1.0",
+						"@smithy/property-provider": "^4.0.5",
+						"@smithy/smithy-client": "^4.4.10",
+						"@smithy/types": "^4.3.2",
 						"bowser": "^2.11.0",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/util-defaults-mode-node": {
-					"version": "4.0.7",
-					"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.7.tgz",
-					"integrity": "sha512-79fQW3hnfCdrfIi1soPbK3zmooRFnLpSx3Vxi6nUlqaaQeC5dm8plt4OTNDNqEEEDkvKghZSaoti684dQFVrGQ==",
+					"version": "4.0.26",
+					"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.26.tgz",
+					"integrity": "sha512-z81yyIkGiLLYVDetKTUeCZQ8x20EEzvQjrqJtb/mXnevLq2+w3XCEWTJ2pMp401b6BkEkHVfXb/cROBpVauLMQ==",
 					"requires": {
-						"@smithy/config-resolver": "^4.0.1",
-						"@smithy/credential-provider-imds": "^4.0.1",
-						"@smithy/node-config-provider": "^4.0.1",
-						"@smithy/property-provider": "^4.0.1",
-						"@smithy/smithy-client": "^4.1.6",
-						"@smithy/types": "^4.1.0",
+						"@smithy/config-resolver": "^4.1.5",
+						"@smithy/credential-provider-imds": "^4.0.7",
+						"@smithy/node-config-provider": "^4.1.4",
+						"@smithy/property-provider": "^4.0.5",
+						"@smithy/smithy-client": "^4.4.10",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/util-endpoints": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.1.tgz",
-					"integrity": "sha512-zVdUENQpdtn9jbpD9SCFK4+aSiavRb9BxEtw9ZGUR1TYo6bBHbIoi7VkrFQ0/RwZlzx0wRBaRmPclj8iAoJCLA==",
+					"version": "3.0.7",
+					"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.7.tgz",
+					"integrity": "sha512-klGBP+RpBp6V5JbrY2C/VKnHXn3d5V2YrifZbmMY8os7M6m8wdYFoO6w/fe5VkP+YVwrEktW3IWYaSQVNZJ8oQ==",
 					"requires": {
-						"@smithy/node-config-provider": "^4.0.1",
-						"@smithy/types": "^4.1.0",
+						"@smithy/node-config-provider": "^4.1.4",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
@@ -33821,32 +34379,32 @@
 					}
 				},
 				"@smithy/util-middleware": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
-					"integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.5.tgz",
+					"integrity": "sha512-N40PfqsZHRSsByGB81HhSo+uvMxEHT+9e255S53pfBw/wI6WKDI7Jw9oyu5tJTLwZzV5DsMha3ji8jk9dsHmQQ==",
 					"requires": {
-						"@smithy/types": "^4.1.0",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/util-retry": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.1.tgz",
-					"integrity": "sha512-WmRHqNVwn3kI3rKk1LsKcVgPBG6iLTBGC1iYOV3GQegwJ3E8yjzHytPt26VNzOWr1qu0xE03nK0Ug8S7T7oufw==",
+					"version": "4.0.7",
+					"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.7.tgz",
+					"integrity": "sha512-TTO6rt0ppK70alZpkjwy+3nQlTiqNfoXja+qwuAchIEAIoSZW8Qyd76dvBv3I5bCpE38APafG23Y/u270NspiQ==",
 					"requires": {
-						"@smithy/service-error-classification": "^4.0.1",
-						"@smithy/types": "^4.1.0",
+						"@smithy/service-error-classification": "^4.0.7",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/util-stream": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.1.2.tgz",
-					"integrity": "sha512-44PKEqQ303d3rlQuiDpcCcu//hV8sn+u2JBo84dWCE0rvgeiVl0IlLMagbU++o0jCWhYCsHaAt9wZuZqNe05Hw==",
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.4.tgz",
+					"integrity": "sha512-vSKnvNZX2BXzl0U2RgCLOwWaAP9x/ddd/XobPK02pCbzRm5s55M53uwb1rl/Ts7RXZvdJZerPkA+en2FDghLuQ==",
 					"requires": {
-						"@smithy/fetch-http-handler": "^5.0.1",
-						"@smithy/node-http-handler": "^4.0.3",
-						"@smithy/types": "^4.1.0",
+						"@smithy/fetch-http-handler": "^5.1.1",
+						"@smithy/node-http-handler": "^4.1.1",
+						"@smithy/types": "^4.3.2",
 						"@smithy/util-base64": "^4.0.0",
 						"@smithy/util-buffer-from": "^4.0.0",
 						"@smithy/util-hex-encoding": "^4.0.0",
@@ -33871,10 +34429,23 @@
 						"tslib": "^2.6.2"
 					}
 				},
+				"fast-xml-parser": {
+					"version": "5.2.5",
+					"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+					"integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+					"requires": {
+						"strnum": "^2.1.0"
+					}
+				},
+				"strnum": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+					"integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw=="
+				},
 				"tslib": {
-					"version": "2.6.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-					"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+					"version": "2.8.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+					"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
 				},
 				"uuid": {
 					"version": "9.0.1",
@@ -35643,6 +36214,114 @@
 				}
 			}
 		},
+		"@aws-sdk/eventstream-handler-node": {
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.873.0.tgz",
+			"integrity": "sha512-c3j9Q3RSR4+/01oHgx8b4WuD2HinVAalbsL7rJKlw86sP6ef1Gq7rVYFn74Ooh+2fIVecvX3cla/tdkR8PwBtA==",
+			"requires": {
+				"@aws-sdk/types": "3.862.0",
+				"@smithy/eventstream-codec": "^4.0.5",
+				"@smithy/types": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"dependencies": {
+				"@aws-crypto/crc32": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+					"integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+					"requires": {
+						"@aws-crypto/util": "^5.2.0",
+						"@aws-sdk/types": "^3.222.0",
+						"tslib": "^2.6.2"
+					}
+				},
+				"@aws-sdk/types": {
+					"version": "3.862.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.862.0.tgz",
+					"integrity": "sha512-Bei+RL0cDxxV+lW2UezLbCYYNeJm6Nzee0TpW0FfyTRBhH9C1XQh4+x+IClriXvgBnRquTMMYsmJfvx8iyLKrg==",
+					"requires": {
+						"@smithy/types": "^4.3.2",
+						"tslib": "^2.6.2"
+					}
+				},
+				"@smithy/eventstream-codec": {
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.0.5.tgz",
+					"integrity": "sha512-miEUN+nz2UTNoRYRhRqVTJCx7jMeILdAurStT2XoS+mhokkmz1xAPp95DFW9Gxt4iF2VBqpeF9HbTQ3kY1viOA==",
+					"requires": {
+						"@aws-crypto/crc32": "5.2.0",
+						"@smithy/types": "^4.3.2",
+						"@smithy/util-hex-encoding": "^4.0.0",
+						"tslib": "^2.6.2"
+					}
+				},
+				"@smithy/types": {
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
+					"integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
+					"requires": {
+						"tslib": "^2.6.2"
+					}
+				},
+				"@smithy/util-hex-encoding": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
+					"integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+					"requires": {
+						"tslib": "^2.6.2"
+					}
+				},
+				"tslib": {
+					"version": "2.8.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+					"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+				}
+			}
+		},
+		"@aws-sdk/middleware-eventstream": {
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.873.0.tgz",
+			"integrity": "sha512-x/BFHxZcfL6siwAPILmF8bGuWAmxDhrXvTlxJZOwwozWnhgRSxgxX2sitpWGvS8pL64DoABwCWSgsgyoXJlMFw==",
+			"requires": {
+				"@aws-sdk/types": "3.862.0",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/types": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"dependencies": {
+				"@aws-sdk/types": {
+					"version": "3.862.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.862.0.tgz",
+					"integrity": "sha512-Bei+RL0cDxxV+lW2UezLbCYYNeJm6Nzee0TpW0FfyTRBhH9C1XQh4+x+IClriXvgBnRquTMMYsmJfvx8iyLKrg==",
+					"requires": {
+						"@smithy/types": "^4.3.2",
+						"tslib": "^2.6.2"
+					}
+				},
+				"@smithy/protocol-http": {
+					"version": "5.1.3",
+					"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.3.tgz",
+					"integrity": "sha512-fCJd2ZR7D22XhDY0l+92pUag/7je2BztPRQ01gU5bMChcyI0rlly7QFibnYHzcxDvccMjlpM/Q1ev8ceRIb48w==",
+					"requires": {
+						"@smithy/types": "^4.3.2",
+						"tslib": "^2.6.2"
+					}
+				},
+				"@smithy/types": {
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
+					"integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
+					"requires": {
+						"tslib": "^2.6.2"
+					}
+				},
+				"tslib": {
+					"version": "2.8.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+					"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+				}
+			}
+		},
 		"@aws-sdk/middleware-host-header": {
 			"version": "3.620.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
@@ -35774,248 +36453,425 @@
 				}
 			}
 		},
+		"@aws-sdk/middleware-websocket": {
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.873.0.tgz",
+			"integrity": "sha512-NLh9JmE460/WIVlsoP4vR5zbgPu50uVHXiEyr5lf34MatayiMTiC7Dd9KecKys8tppVVqahOMkOLb4/nl0hk6Q==",
+			"requires": {
+				"@aws-sdk/types": "3.862.0",
+				"@aws-sdk/util-format-url": "3.873.0",
+				"@smithy/eventstream-codec": "^4.0.5",
+				"@smithy/eventstream-serde-browser": "^4.0.5",
+				"@smithy/fetch-http-handler": "^5.1.1",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/signature-v4": "^5.1.3",
+				"@smithy/types": "^4.3.2",
+				"@smithy/util-hex-encoding": "^4.0.0",
+				"tslib": "^2.6.2"
+			},
+			"dependencies": {
+				"@aws-crypto/crc32": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+					"integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+					"requires": {
+						"@aws-crypto/util": "^5.2.0",
+						"@aws-sdk/types": "^3.222.0",
+						"tslib": "^2.6.2"
+					}
+				},
+				"@aws-sdk/types": {
+					"version": "3.862.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.862.0.tgz",
+					"integrity": "sha512-Bei+RL0cDxxV+lW2UezLbCYYNeJm6Nzee0TpW0FfyTRBhH9C1XQh4+x+IClriXvgBnRquTMMYsmJfvx8iyLKrg==",
+					"requires": {
+						"@smithy/types": "^4.3.2",
+						"tslib": "^2.6.2"
+					}
+				},
+				"@smithy/eventstream-codec": {
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.0.5.tgz",
+					"integrity": "sha512-miEUN+nz2UTNoRYRhRqVTJCx7jMeILdAurStT2XoS+mhokkmz1xAPp95DFW9Gxt4iF2VBqpeF9HbTQ3kY1viOA==",
+					"requires": {
+						"@aws-crypto/crc32": "5.2.0",
+						"@smithy/types": "^4.3.2",
+						"@smithy/util-hex-encoding": "^4.0.0",
+						"tslib": "^2.6.2"
+					}
+				},
+				"@smithy/fetch-http-handler": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.1.1.tgz",
+					"integrity": "sha512-61WjM0PWmZJR+SnmzaKI7t7G0UkkNFboDpzIdzSoy7TByUzlxo18Qlh9s71qug4AY4hlH/CwXdubMtkcNEb/sQ==",
+					"requires": {
+						"@smithy/protocol-http": "^5.1.3",
+						"@smithy/querystring-builder": "^4.0.5",
+						"@smithy/types": "^4.3.2",
+						"@smithy/util-base64": "^4.0.0",
+						"tslib": "^2.6.2"
+					}
+				},
+				"@smithy/is-array-buffer": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+					"integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+					"requires": {
+						"tslib": "^2.6.2"
+					}
+				},
+				"@smithy/protocol-http": {
+					"version": "5.1.3",
+					"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.3.tgz",
+					"integrity": "sha512-fCJd2ZR7D22XhDY0l+92pUag/7je2BztPRQ01gU5bMChcyI0rlly7QFibnYHzcxDvccMjlpM/Q1ev8ceRIb48w==",
+					"requires": {
+						"@smithy/types": "^4.3.2",
+						"tslib": "^2.6.2"
+					}
+				},
+				"@smithy/querystring-builder": {
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.5.tgz",
+					"integrity": "sha512-NJeSCU57piZ56c+/wY+AbAw6rxCCAOZLCIniRE7wqvndqxcKKDOXzwWjrY7wGKEISfhL9gBbAaWWgHsUGedk+A==",
+					"requires": {
+						"@smithy/types": "^4.3.2",
+						"@smithy/util-uri-escape": "^4.0.0",
+						"tslib": "^2.6.2"
+					}
+				},
+				"@smithy/signature-v4": {
+					"version": "5.1.3",
+					"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.3.tgz",
+					"integrity": "sha512-mARDSXSEgllNzMw6N+mC+r1AQlEBO3meEAkR/UlfAgnMzJUB3goRBWgip1EAMG99wh36MDqzo86SfIX5Y+VEaw==",
+					"requires": {
+						"@smithy/is-array-buffer": "^4.0.0",
+						"@smithy/protocol-http": "^5.1.3",
+						"@smithy/types": "^4.3.2",
+						"@smithy/util-hex-encoding": "^4.0.0",
+						"@smithy/util-middleware": "^4.0.5",
+						"@smithy/util-uri-escape": "^4.0.0",
+						"@smithy/util-utf8": "^4.0.0",
+						"tslib": "^2.6.2"
+					}
+				},
+				"@smithy/types": {
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
+					"integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
+					"requires": {
+						"tslib": "^2.6.2"
+					}
+				},
+				"@smithy/util-base64": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
+					"integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+					"requires": {
+						"@smithy/util-buffer-from": "^4.0.0",
+						"@smithy/util-utf8": "^4.0.0",
+						"tslib": "^2.6.2"
+					}
+				},
+				"@smithy/util-buffer-from": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+					"integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+					"requires": {
+						"@smithy/is-array-buffer": "^4.0.0",
+						"tslib": "^2.6.2"
+					}
+				},
+				"@smithy/util-hex-encoding": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
+					"integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+					"requires": {
+						"tslib": "^2.6.2"
+					}
+				},
+				"@smithy/util-middleware": {
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.5.tgz",
+					"integrity": "sha512-N40PfqsZHRSsByGB81HhSo+uvMxEHT+9e255S53pfBw/wI6WKDI7Jw9oyu5tJTLwZzV5DsMha3ji8jk9dsHmQQ==",
+					"requires": {
+						"@smithy/types": "^4.3.2",
+						"tslib": "^2.6.2"
+					}
+				},
+				"@smithy/util-uri-escape": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
+					"integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+					"requires": {
+						"tslib": "^2.6.2"
+					}
+				},
+				"@smithy/util-utf8": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+					"integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+					"requires": {
+						"@smithy/util-buffer-from": "^4.0.0",
+						"tslib": "^2.6.2"
+					}
+				},
+				"tslib": {
+					"version": "2.8.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+					"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+				}
+			}
+		},
 		"@aws-sdk/nested-clients": {
-			"version": "3.758.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.758.0.tgz",
-			"integrity": "sha512-YZ5s7PSvyF3Mt2h1EQulCG93uybprNGbBkPmVuy/HMMfbFTt4iL3SbKjxqvOZelm86epFfj7pvK7FliI2WOEcg==",
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.873.0.tgz",
+			"integrity": "sha512-yg8JkRHuH/xO65rtmLOWcd9XQhxX1kAonp2CliXT44eA/23OBds6XoheY44eZeHfCTgutDLTYitvy3k9fQY6ZA==",
 			"requires": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.758.0",
-				"@aws-sdk/middleware-host-header": "3.734.0",
-				"@aws-sdk/middleware-logger": "3.734.0",
-				"@aws-sdk/middleware-recursion-detection": "3.734.0",
-				"@aws-sdk/middleware-user-agent": "3.758.0",
-				"@aws-sdk/region-config-resolver": "3.734.0",
-				"@aws-sdk/types": "3.734.0",
-				"@aws-sdk/util-endpoints": "3.743.0",
-				"@aws-sdk/util-user-agent-browser": "3.734.0",
-				"@aws-sdk/util-user-agent-node": "3.758.0",
-				"@smithy/config-resolver": "^4.0.1",
-				"@smithy/core": "^3.1.5",
-				"@smithy/fetch-http-handler": "^5.0.1",
-				"@smithy/hash-node": "^4.0.1",
-				"@smithy/invalid-dependency": "^4.0.1",
-				"@smithy/middleware-content-length": "^4.0.1",
-				"@smithy/middleware-endpoint": "^4.0.6",
-				"@smithy/middleware-retry": "^4.0.7",
-				"@smithy/middleware-serde": "^4.0.2",
-				"@smithy/middleware-stack": "^4.0.1",
-				"@smithy/node-config-provider": "^4.0.1",
-				"@smithy/node-http-handler": "^4.0.3",
-				"@smithy/protocol-http": "^5.0.1",
-				"@smithy/smithy-client": "^4.1.6",
-				"@smithy/types": "^4.1.0",
-				"@smithy/url-parser": "^4.0.1",
+				"@aws-sdk/core": "3.873.0",
+				"@aws-sdk/middleware-host-header": "3.873.0",
+				"@aws-sdk/middleware-logger": "3.873.0",
+				"@aws-sdk/middleware-recursion-detection": "3.873.0",
+				"@aws-sdk/middleware-user-agent": "3.873.0",
+				"@aws-sdk/region-config-resolver": "3.873.0",
+				"@aws-sdk/types": "3.862.0",
+				"@aws-sdk/util-endpoints": "3.873.0",
+				"@aws-sdk/util-user-agent-browser": "3.873.0",
+				"@aws-sdk/util-user-agent-node": "3.873.0",
+				"@smithy/config-resolver": "^4.1.5",
+				"@smithy/core": "^3.8.0",
+				"@smithy/fetch-http-handler": "^5.1.1",
+				"@smithy/hash-node": "^4.0.5",
+				"@smithy/invalid-dependency": "^4.0.5",
+				"@smithy/middleware-content-length": "^4.0.5",
+				"@smithy/middleware-endpoint": "^4.1.18",
+				"@smithy/middleware-retry": "^4.1.19",
+				"@smithy/middleware-serde": "^4.0.9",
+				"@smithy/middleware-stack": "^4.0.5",
+				"@smithy/node-config-provider": "^4.1.4",
+				"@smithy/node-http-handler": "^4.1.1",
+				"@smithy/protocol-http": "^5.1.3",
+				"@smithy/smithy-client": "^4.4.10",
+				"@smithy/types": "^4.3.2",
+				"@smithy/url-parser": "^4.0.5",
 				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-body-length-browser": "^4.0.0",
 				"@smithy/util-body-length-node": "^4.0.0",
-				"@smithy/util-defaults-mode-browser": "^4.0.7",
-				"@smithy/util-defaults-mode-node": "^4.0.7",
-				"@smithy/util-endpoints": "^3.0.1",
-				"@smithy/util-middleware": "^4.0.1",
-				"@smithy/util-retry": "^4.0.1",
+				"@smithy/util-defaults-mode-browser": "^4.0.26",
+				"@smithy/util-defaults-mode-node": "^4.0.26",
+				"@smithy/util-endpoints": "^3.0.7",
+				"@smithy/util-middleware": "^4.0.5",
+				"@smithy/util-retry": "^4.0.7",
 				"@smithy/util-utf8": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
 			"dependencies": {
 				"@aws-sdk/core": {
-					"version": "3.758.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.758.0.tgz",
-					"integrity": "sha512-0RswbdR9jt/XKemaLNuxi2gGr4xGlHyGxkTdhSQzCyUe9A9OPCoLl3rIESRguQEech+oJnbHk/wuiwHqTuP9sg==",
+					"version": "3.873.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.873.0.tgz",
+					"integrity": "sha512-WrROjp8X1VvmnZ4TBzwM7RF+EB3wRaY9kQJLXw+Aes0/3zRjUXvGIlseobGJMqMEGnM0YekD2F87UaVfot1xeQ==",
 					"requires": {
-						"@aws-sdk/types": "3.734.0",
-						"@smithy/core": "^3.1.5",
-						"@smithy/node-config-provider": "^4.0.1",
-						"@smithy/property-provider": "^4.0.1",
-						"@smithy/protocol-http": "^5.0.1",
-						"@smithy/signature-v4": "^5.0.1",
-						"@smithy/smithy-client": "^4.1.6",
-						"@smithy/types": "^4.1.0",
-						"@smithy/util-middleware": "^4.0.1",
-						"fast-xml-parser": "4.4.1",
+						"@aws-sdk/types": "3.862.0",
+						"@aws-sdk/xml-builder": "3.873.0",
+						"@smithy/core": "^3.8.0",
+						"@smithy/node-config-provider": "^4.1.4",
+						"@smithy/property-provider": "^4.0.5",
+						"@smithy/protocol-http": "^5.1.3",
+						"@smithy/signature-v4": "^5.1.3",
+						"@smithy/smithy-client": "^4.4.10",
+						"@smithy/types": "^4.3.2",
+						"@smithy/util-base64": "^4.0.0",
+						"@smithy/util-body-length-browser": "^4.0.0",
+						"@smithy/util-middleware": "^4.0.5",
+						"@smithy/util-utf8": "^4.0.0",
+						"fast-xml-parser": "5.2.5",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@aws-sdk/middleware-host-header": {
-					"version": "3.734.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.734.0.tgz",
-					"integrity": "sha512-LW7RRgSOHHBzWZnigNsDIzu3AiwtjeI2X66v+Wn1P1u+eXssy1+up4ZY/h+t2sU4LU36UvEf+jrZti9c6vRnFw==",
+					"version": "3.873.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.873.0.tgz",
+					"integrity": "sha512-KZ/W1uruWtMOs7D5j3KquOxzCnV79KQW9MjJFZM/M0l6KI8J6V3718MXxFHsTjUE4fpdV6SeCNLV1lwGygsjJA==",
 					"requires": {
-						"@aws-sdk/types": "3.734.0",
-						"@smithy/protocol-http": "^5.0.1",
-						"@smithy/types": "^4.1.0",
+						"@aws-sdk/types": "3.862.0",
+						"@smithy/protocol-http": "^5.1.3",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@aws-sdk/middleware-logger": {
-					"version": "3.734.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.734.0.tgz",
-					"integrity": "sha512-mUMFITpJUW3LcKvFok176eI5zXAUomVtahb9IQBwLzkqFYOrMJvWAvoV4yuxrJ8TlQBG8gyEnkb9SnhZvjg67w==",
+					"version": "3.873.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.873.0.tgz",
+					"integrity": "sha512-QhNZ8X7pW68kFez9QxUSN65Um0Feo18ZmHxszQZNUhKDsXew/EG9NPQE/HgYcekcon35zHxC4xs+FeNuPurP2g==",
 					"requires": {
-						"@aws-sdk/types": "3.734.0",
-						"@smithy/types": "^4.1.0",
+						"@aws-sdk/types": "3.862.0",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@aws-sdk/middleware-recursion-detection": {
-					"version": "3.734.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.734.0.tgz",
-					"integrity": "sha512-CUat2d9ITsFc2XsmeiRQO96iWpxSKYFjxvj27Hc7vo87YUHRnfMfnc8jw1EpxEwMcvBD7LsRa6vDNky6AjcrFA==",
+					"version": "3.873.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.873.0.tgz",
+					"integrity": "sha512-OtgY8EXOzRdEWR//WfPkA/fXl0+WwE8hq0y9iw2caNyKPtca85dzrrZWnPqyBK/cpImosrpR1iKMYr41XshsCg==",
 					"requires": {
-						"@aws-sdk/types": "3.734.0",
-						"@smithy/protocol-http": "^5.0.1",
-						"@smithy/types": "^4.1.0",
+						"@aws-sdk/types": "3.862.0",
+						"@smithy/protocol-http": "^5.1.3",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@aws-sdk/middleware-user-agent": {
-					"version": "3.758.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.758.0.tgz",
-					"integrity": "sha512-iNyehQXtQlj69JCgfaOssgZD4HeYGOwxcaKeG6F+40cwBjTAi0+Ph1yfDwqk2qiBPIRWJ/9l2LodZbxiBqgrwg==",
+					"version": "3.873.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.873.0.tgz",
+					"integrity": "sha512-gHqAMYpWkPhZLwqB3Yj83JKdL2Vsb64sryo8LN2UdpElpS+0fT4yjqSxKTfp7gkhN6TCIxF24HQgbPk5FMYJWw==",
 					"requires": {
-						"@aws-sdk/core": "3.758.0",
-						"@aws-sdk/types": "3.734.0",
-						"@aws-sdk/util-endpoints": "3.743.0",
-						"@smithy/core": "^3.1.5",
-						"@smithy/protocol-http": "^5.0.1",
-						"@smithy/types": "^4.1.0",
+						"@aws-sdk/core": "3.873.0",
+						"@aws-sdk/types": "3.862.0",
+						"@aws-sdk/util-endpoints": "3.873.0",
+						"@smithy/core": "^3.8.0",
+						"@smithy/protocol-http": "^5.1.3",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@aws-sdk/region-config-resolver": {
-					"version": "3.734.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.734.0.tgz",
-					"integrity": "sha512-Lvj1kPRC5IuJBr9DyJ9T9/plkh+EfKLy+12s/mykOy1JaKHDpvj+XGy2YO6YgYVOb8JFtaqloid+5COtje4JTQ==",
+					"version": "3.873.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.873.0.tgz",
+					"integrity": "sha512-q9sPoef+BBG6PJnc4x60vK/bfVwvRWsPgcoQyIra057S/QGjq5VkjvNk6H8xedf6vnKlXNBwq9BaANBXnldUJg==",
 					"requires": {
-						"@aws-sdk/types": "3.734.0",
-						"@smithy/node-config-provider": "^4.0.1",
-						"@smithy/types": "^4.1.0",
+						"@aws-sdk/types": "3.862.0",
+						"@smithy/node-config-provider": "^4.1.4",
+						"@smithy/types": "^4.3.2",
 						"@smithy/util-config-provider": "^4.0.0",
-						"@smithy/util-middleware": "^4.0.1",
+						"@smithy/util-middleware": "^4.0.5",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@aws-sdk/types": {
-					"version": "3.734.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.734.0.tgz",
-					"integrity": "sha512-o11tSPTT70nAkGV1fN9wm/hAIiLPyWX6SuGf+9JyTp7S/rC2cFWhR26MvA69nplcjNaXVzB0f+QFrLXXjOqCrg==",
+					"version": "3.862.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.862.0.tgz",
+					"integrity": "sha512-Bei+RL0cDxxV+lW2UezLbCYYNeJm6Nzee0TpW0FfyTRBhH9C1XQh4+x+IClriXvgBnRquTMMYsmJfvx8iyLKrg==",
 					"requires": {
-						"@smithy/types": "^4.1.0",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@aws-sdk/util-endpoints": {
-					"version": "3.743.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.743.0.tgz",
-					"integrity": "sha512-sN1l559zrixeh5x+pttrnd0A3+r34r0tmPkJ/eaaMaAzXqsmKU/xYre9K3FNnsSS1J1k4PEfk/nHDTVUgFYjnw==",
+					"version": "3.873.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.873.0.tgz",
+					"integrity": "sha512-YByHrhjxYdjKRf/RQygRK1uh0As1FIi9+jXTcIEX/rBgN8mUByczr2u4QXBzw7ZdbdcOBMOkPnLRjNOWW1MkFg==",
 					"requires": {
-						"@aws-sdk/types": "3.734.0",
-						"@smithy/types": "^4.1.0",
-						"@smithy/util-endpoints": "^3.0.1",
+						"@aws-sdk/types": "3.862.0",
+						"@smithy/types": "^4.3.2",
+						"@smithy/url-parser": "^4.0.5",
+						"@smithy/util-endpoints": "^3.0.7",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@aws-sdk/util-user-agent-browser": {
-					"version": "3.734.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.734.0.tgz",
-					"integrity": "sha512-xQTCus6Q9LwUuALW+S76OL0jcWtMOVu14q+GoLnWPUM7QeUw963oQcLhF7oq0CtaLLKyl4GOUfcwc773Zmwwng==",
+					"version": "3.873.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.873.0.tgz",
+					"integrity": "sha512-AcRdbK6o19yehEcywI43blIBhOCSo6UgyWcuOJX5CFF8k39xm1ILCjQlRRjchLAxWrm0lU0Q7XV90RiMMFMZtA==",
 					"requires": {
-						"@aws-sdk/types": "3.734.0",
-						"@smithy/types": "^4.1.0",
+						"@aws-sdk/types": "3.862.0",
+						"@smithy/types": "^4.3.2",
 						"bowser": "^2.11.0",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@aws-sdk/util-user-agent-node": {
-					"version": "3.758.0",
-					"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.758.0.tgz",
-					"integrity": "sha512-A5EZw85V6WhoKMV2hbuFRvb9NPlxEErb4HPO6/SPXYY4QrjprIzScHxikqcWv1w4J3apB1wto9LPU3IMsYtfrw==",
+					"version": "3.873.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.873.0.tgz",
+					"integrity": "sha512-9MivTP+q9Sis71UxuBaIY3h5jxH0vN3/ZWGxO8ADL19S2OIfknrYSAfzE5fpoKROVBu0bS4VifHOFq4PY1zsxw==",
 					"requires": {
-						"@aws-sdk/middleware-user-agent": "3.758.0",
-						"@aws-sdk/types": "3.734.0",
-						"@smithy/node-config-provider": "^4.0.1",
-						"@smithy/types": "^4.1.0",
+						"@aws-sdk/middleware-user-agent": "3.873.0",
+						"@aws-sdk/types": "3.862.0",
+						"@smithy/node-config-provider": "^4.1.4",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/abort-controller": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
-					"integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.5.tgz",
+					"integrity": "sha512-jcrqdTQurIrBbUm4W2YdLVMQDoL0sA9DTxYd2s+R/y+2U9NLOP7Xf/YqfSg1FZhlZIYEnvk2mwbyvIfdLEPo8g==",
 					"requires": {
-						"@smithy/types": "^4.1.0",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/config-resolver": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.0.1.tgz",
-					"integrity": "sha512-Igfg8lKu3dRVkTSEm98QpZUvKEOa71jDX4vKRcvJVyRc3UgN3j7vFMf0s7xLQhYmKa8kyJGQgUJDOV5V3neVlQ==",
+					"version": "4.1.5",
+					"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.5.tgz",
+					"integrity": "sha512-viuHMxBAqydkB0AfWwHIdwf/PRH2z5KHGUzqyRtS/Wv+n3IHI993Sk76VCA7dD/+GzgGOmlJDITfPcJC1nIVIw==",
 					"requires": {
-						"@smithy/node-config-provider": "^4.0.1",
-						"@smithy/types": "^4.1.0",
+						"@smithy/node-config-provider": "^4.1.4",
+						"@smithy/types": "^4.3.2",
 						"@smithy/util-config-provider": "^4.0.0",
-						"@smithy/util-middleware": "^4.0.1",
+						"@smithy/util-middleware": "^4.0.5",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/core": {
-					"version": "3.1.5",
-					"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.5.tgz",
-					"integrity": "sha512-HLclGWPkCsekQgsyzxLhCQLa8THWXtB5PxyYN+2O6nkyLt550KQKTlbV2D1/j5dNIQapAZM1+qFnpBFxZQkgCA==",
+					"version": "3.8.0",
+					"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.8.0.tgz",
+					"integrity": "sha512-EYqsIYJmkR1VhVE9pccnk353xhs+lB6btdutJEtsp7R055haMJp2yE16eSxw8fv+G0WUY6vqxyYOP8kOqawxYQ==",
 					"requires": {
-						"@smithy/middleware-serde": "^4.0.2",
-						"@smithy/protocol-http": "^5.0.1",
-						"@smithy/types": "^4.1.0",
+						"@smithy/middleware-serde": "^4.0.9",
+						"@smithy/protocol-http": "^5.1.3",
+						"@smithy/types": "^4.3.2",
+						"@smithy/util-base64": "^4.0.0",
 						"@smithy/util-body-length-browser": "^4.0.0",
-						"@smithy/util-middleware": "^4.0.1",
-						"@smithy/util-stream": "^4.1.2",
+						"@smithy/util-middleware": "^4.0.5",
+						"@smithy/util-stream": "^4.2.4",
 						"@smithy/util-utf8": "^4.0.0",
-						"tslib": "^2.6.2"
+						"@types/uuid": "^9.0.1",
+						"tslib": "^2.6.2",
+						"uuid": "^9.0.1"
 					}
 				},
 				"@smithy/credential-provider-imds": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.1.tgz",
-					"integrity": "sha512-l/qdInaDq1Zpznpmev/+52QomsJNZ3JkTl5yrTl02V6NBgJOQ4LY0SFw/8zsMwj3tLe8vqiIuwF6nxaEwgf6mg==",
+					"version": "4.0.7",
+					"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.7.tgz",
+					"integrity": "sha512-dDzrMXA8d8riFNiPvytxn0mNwR4B3h8lgrQ5UjAGu6T9z/kRg/Xncf4tEQHE/+t25sY8IH3CowcmWi+1U5B1Gw==",
 					"requires": {
-						"@smithy/node-config-provider": "^4.0.1",
-						"@smithy/property-provider": "^4.0.1",
-						"@smithy/types": "^4.1.0",
-						"@smithy/url-parser": "^4.0.1",
+						"@smithy/node-config-provider": "^4.1.4",
+						"@smithy/property-provider": "^4.0.5",
+						"@smithy/types": "^4.3.2",
+						"@smithy/url-parser": "^4.0.5",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/fetch-http-handler": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.1.tgz",
-					"integrity": "sha512-3aS+fP28urrMW2KTjb6z9iFow6jO8n3MFfineGbndvzGZit3taZhKWtTorf+Gp5RpFDDafeHlhfsGlDCXvUnJA==",
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.1.1.tgz",
+					"integrity": "sha512-61WjM0PWmZJR+SnmzaKI7t7G0UkkNFboDpzIdzSoy7TByUzlxo18Qlh9s71qug4AY4hlH/CwXdubMtkcNEb/sQ==",
 					"requires": {
-						"@smithy/protocol-http": "^5.0.1",
-						"@smithy/querystring-builder": "^4.0.1",
-						"@smithy/types": "^4.1.0",
+						"@smithy/protocol-http": "^5.1.3",
+						"@smithy/querystring-builder": "^4.0.5",
+						"@smithy/types": "^4.3.2",
 						"@smithy/util-base64": "^4.0.0",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/hash-node": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.1.tgz",
-					"integrity": "sha512-TJ6oZS+3r2Xu4emVse1YPB3Dq3d8RkZDKcPr71Nj/lJsdAP1c7oFzYqEn1IBc915TsgLl2xIJNuxCz+gLbLE0w==",
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.5.tgz",
+					"integrity": "sha512-cv1HHkKhpyRb6ahD8Vcfb2Hgz67vNIXEp2vnhzfxLFGRukLCNEA5QdsorbUEzXma1Rco0u3rx5VTqbM06GcZqQ==",
 					"requires": {
-						"@smithy/types": "^4.1.0",
+						"@smithy/types": "^4.3.2",
 						"@smithy/util-buffer-from": "^4.0.0",
 						"@smithy/util-utf8": "^4.0.0",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/invalid-dependency": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.1.tgz",
-					"integrity": "sha512-gdudFPf4QRQ5pzj7HEnu6FhKRi61BfH/Gk5Yf6O0KiSbr1LlVhgjThcvjdu658VE6Nve8vaIWB8/fodmS1rBPQ==",
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.5.tgz",
+					"integrity": "sha512-IVnb78Qtf7EJpoEVo7qJ8BEXQwgC4n3igeJNNKEj/MLYtapnx8A67Zt/J3RXAj2xSO1910zk0LdFiygSemuLow==",
 					"requires": {
-						"@smithy/types": "^4.1.0",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
@@ -36028,185 +36884,187 @@
 					}
 				},
 				"@smithy/middleware-content-length": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.1.tgz",
-					"integrity": "sha512-OGXo7w5EkB5pPiac7KNzVtfCW2vKBTZNuCctn++TTSOMpe6RZO/n6WEC1AxJINn3+vWLKW49uad3lo/u0WJ9oQ==",
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.5.tgz",
+					"integrity": "sha512-l1jlNZoYzoCC7p0zCtBDE5OBXZ95yMKlRlftooE5jPWQn4YBPLgsp+oeHp7iMHaTGoUdFqmHOPa8c9G3gBsRpQ==",
 					"requires": {
-						"@smithy/protocol-http": "^5.0.1",
-						"@smithy/types": "^4.1.0",
+						"@smithy/protocol-http": "^5.1.3",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/middleware-endpoint": {
-					"version": "4.0.6",
-					"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.6.tgz",
-					"integrity": "sha512-ftpmkTHIFqgaFugcjzLZv3kzPEFsBFSnq1JsIkr2mwFzCraZVhQk2gqN51OOeRxqhbPTkRFj39Qd2V91E/mQxg==",
+					"version": "4.1.18",
+					"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.18.tgz",
+					"integrity": "sha512-ZhvqcVRPZxnZlokcPaTwb+r+h4yOIOCJmx0v2d1bpVlmP465g3qpVSf7wxcq5zZdu4jb0H4yIMxuPwDJSQc3MQ==",
 					"requires": {
-						"@smithy/core": "^3.1.5",
-						"@smithy/middleware-serde": "^4.0.2",
-						"@smithy/node-config-provider": "^4.0.1",
-						"@smithy/shared-ini-file-loader": "^4.0.1",
-						"@smithy/types": "^4.1.0",
-						"@smithy/url-parser": "^4.0.1",
-						"@smithy/util-middleware": "^4.0.1",
+						"@smithy/core": "^3.8.0",
+						"@smithy/middleware-serde": "^4.0.9",
+						"@smithy/node-config-provider": "^4.1.4",
+						"@smithy/shared-ini-file-loader": "^4.0.5",
+						"@smithy/types": "^4.3.2",
+						"@smithy/url-parser": "^4.0.5",
+						"@smithy/util-middleware": "^4.0.5",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/middleware-retry": {
-					"version": "4.0.7",
-					"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.0.7.tgz",
-					"integrity": "sha512-58j9XbUPLkqAcV1kHzVX/kAR16GT+j7DUZJqwzsxh1jtz7G82caZiGyyFgUvogVfNTg3TeAOIJepGc8TXF4AVQ==",
+					"version": "4.1.19",
+					"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.19.tgz",
+					"integrity": "sha512-X58zx/NVECjeuUB6A8HBu4bhx72EoUz+T5jTMIyeNKx2lf+Gs9TmWPNNkH+5QF0COjpInP/xSpJGJ7xEnAklQQ==",
 					"requires": {
-						"@smithy/node-config-provider": "^4.0.1",
-						"@smithy/protocol-http": "^5.0.1",
-						"@smithy/service-error-classification": "^4.0.1",
-						"@smithy/smithy-client": "^4.1.6",
-						"@smithy/types": "^4.1.0",
-						"@smithy/util-middleware": "^4.0.1",
-						"@smithy/util-retry": "^4.0.1",
+						"@smithy/node-config-provider": "^4.1.4",
+						"@smithy/protocol-http": "^5.1.3",
+						"@smithy/service-error-classification": "^4.0.7",
+						"@smithy/smithy-client": "^4.4.10",
+						"@smithy/types": "^4.3.2",
+						"@smithy/util-middleware": "^4.0.5",
+						"@smithy/util-retry": "^4.0.7",
+						"@types/uuid": "^9.0.1",
 						"tslib": "^2.6.2",
 						"uuid": "^9.0.1"
 					}
 				},
 				"@smithy/middleware-serde": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.2.tgz",
-					"integrity": "sha512-Sdr5lOagCn5tt+zKsaW+U2/iwr6bI9p08wOkCp6/eL6iMbgdtc2R5Ety66rf87PeohR0ExI84Txz9GYv5ou3iQ==",
+					"version": "4.0.9",
+					"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.9.tgz",
+					"integrity": "sha512-uAFFR4dpeoJPGz8x9mhxp+RPjo5wW0QEEIPPPbLXiRRWeCATf/Km3gKIVR5vaP8bN1kgsPhcEeh+IZvUlBv6Xg==",
 					"requires": {
-						"@smithy/types": "^4.1.0",
+						"@smithy/protocol-http": "^5.1.3",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/middleware-stack": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
-					"integrity": "sha512-dHwDmrtR/ln8UTHpaIavRSzeIk5+YZTBtLnKwDW3G2t6nAupCiQUvNzNoHBpik63fwUaJPtlnMzXbQrNFWssIA==",
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.5.tgz",
+					"integrity": "sha512-/yoHDXZPh3ocRVyeWQFvC44u8seu3eYzZRveCMfgMOBcNKnAmOvjbL9+Cp5XKSIi9iYA9PECUuW2teDAk8T+OQ==",
 					"requires": {
-						"@smithy/types": "^4.1.0",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/node-config-provider": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
-					"integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
+					"version": "4.1.4",
+					"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.4.tgz",
+					"integrity": "sha512-+UDQV/k42jLEPPHSn39l0Bmc4sB1xtdI9Gd47fzo/0PbXzJ7ylgaOByVjF5EeQIumkepnrJyfx86dPa9p47Y+w==",
 					"requires": {
-						"@smithy/property-provider": "^4.0.1",
-						"@smithy/shared-ini-file-loader": "^4.0.1",
-						"@smithy/types": "^4.1.0",
+						"@smithy/property-provider": "^4.0.5",
+						"@smithy/shared-ini-file-loader": "^4.0.5",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/node-http-handler": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.3.tgz",
-					"integrity": "sha512-dYCLeINNbYdvmMLtW0VdhW1biXt+PPCGazzT5ZjKw46mOtdgToQEwjqZSS9/EN8+tNs/RO0cEWG044+YZs97aA==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.1.1.tgz",
+					"integrity": "sha512-RHnlHqFpoVdjSPPiYy/t40Zovf3BBHc2oemgD7VsVTFFZrU5erFFe0n52OANZZ/5sbshgD93sOh5r6I35Xmpaw==",
 					"requires": {
-						"@smithy/abort-controller": "^4.0.1",
-						"@smithy/protocol-http": "^5.0.1",
-						"@smithy/querystring-builder": "^4.0.1",
-						"@smithy/types": "^4.1.0",
+						"@smithy/abort-controller": "^4.0.5",
+						"@smithy/protocol-http": "^5.1.3",
+						"@smithy/querystring-builder": "^4.0.5",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/property-provider": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
-					"integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.5.tgz",
+					"integrity": "sha512-R/bswf59T/n9ZgfgUICAZoWYKBHcsVDurAGX88zsiUtOTA/xUAPyiT+qkNCPwFn43pZqN84M4MiUsbSGQmgFIQ==",
 					"requires": {
-						"@smithy/types": "^4.1.0",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/protocol-http": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
-					"integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
+					"version": "5.1.3",
+					"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.3.tgz",
+					"integrity": "sha512-fCJd2ZR7D22XhDY0l+92pUag/7je2BztPRQ01gU5bMChcyI0rlly7QFibnYHzcxDvccMjlpM/Q1ev8ceRIb48w==",
 					"requires": {
-						"@smithy/types": "^4.1.0",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/querystring-builder": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.1.tgz",
-					"integrity": "sha512-wU87iWZoCbcqrwszsOewEIuq+SU2mSoBE2CcsLwE0I19m0B2gOJr1MVjxWcDQYOzHbR1xCk7AcOBbGFUYOKvdg==",
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.5.tgz",
+					"integrity": "sha512-NJeSCU57piZ56c+/wY+AbAw6rxCCAOZLCIniRE7wqvndqxcKKDOXzwWjrY7wGKEISfhL9gBbAaWWgHsUGedk+A==",
 					"requires": {
-						"@smithy/types": "^4.1.0",
+						"@smithy/types": "^4.3.2",
 						"@smithy/util-uri-escape": "^4.0.0",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/querystring-parser": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.1.tgz",
-					"integrity": "sha512-Ma2XC7VS9aV77+clSFylVUnPZRindhB7BbmYiNOdr+CHt/kZNJoPP0cd3QxCnCFyPXC4eybmyE98phEHkqZ5Jw==",
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.5.tgz",
+					"integrity": "sha512-6SV7md2CzNG/WUeTjVe6Dj8noH32r4MnUeFKZrnVYsQxpGSIcphAanQMayi8jJLZAWm6pdM9ZXvKCpWOsIGg0w==",
 					"requires": {
-						"@smithy/types": "^4.1.0",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/service-error-classification": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.1.tgz",
-					"integrity": "sha512-3JNjBfOWpj/mYfjXJHB4Txc/7E4LVq32bwzE7m28GN79+M1f76XHflUaSUkhOriprPDzev9cX/M+dEB80DNDKA==",
+					"version": "4.0.7",
+					"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.7.tgz",
+					"integrity": "sha512-XvRHOipqpwNhEjDf2L5gJowZEm5nsxC16pAZOeEcsygdjv9A2jdOh3YoDQvOXBGTsaJk6mNWtzWalOB9976Wlg==",
 					"requires": {
-						"@smithy/types": "^4.1.0"
+						"@smithy/types": "^4.3.2"
 					}
 				},
 				"@smithy/shared-ini-file-loader": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
-					"integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.5.tgz",
+					"integrity": "sha512-YVVwehRDuehgoXdEL4r1tAAzdaDgaC9EQvhK0lEbfnbrd0bd5+CTQumbdPryX3J2shT7ZqQE+jPW4lmNBAB8JQ==",
 					"requires": {
-						"@smithy/types": "^4.1.0",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/signature-v4": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
-					"integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
+					"version": "5.1.3",
+					"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.3.tgz",
+					"integrity": "sha512-mARDSXSEgllNzMw6N+mC+r1AQlEBO3meEAkR/UlfAgnMzJUB3goRBWgip1EAMG99wh36MDqzo86SfIX5Y+VEaw==",
 					"requires": {
 						"@smithy/is-array-buffer": "^4.0.0",
-						"@smithy/protocol-http": "^5.0.1",
-						"@smithy/types": "^4.1.0",
+						"@smithy/protocol-http": "^5.1.3",
+						"@smithy/types": "^4.3.2",
 						"@smithy/util-hex-encoding": "^4.0.0",
-						"@smithy/util-middleware": "^4.0.1",
+						"@smithy/util-middleware": "^4.0.5",
 						"@smithy/util-uri-escape": "^4.0.0",
 						"@smithy/util-utf8": "^4.0.0",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/smithy-client": {
-					"version": "4.1.6",
-					"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.6.tgz",
-					"integrity": "sha512-UYDolNg6h2O0L+cJjtgSyKKvEKCOa/8FHYJnBobyeoeWDmNpXjwOAtw16ezyeu1ETuuLEOZbrynK0ZY1Lx9Jbw==",
+					"version": "4.4.10",
+					"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.10.tgz",
+					"integrity": "sha512-iW6HjXqN0oPtRS0NK/zzZ4zZeGESIFcxj2FkWed3mcK8jdSdHzvnCKXSjvewESKAgGKAbJRA+OsaqKhkdYRbQQ==",
 					"requires": {
-						"@smithy/core": "^3.1.5",
-						"@smithy/middleware-endpoint": "^4.0.6",
-						"@smithy/middleware-stack": "^4.0.1",
-						"@smithy/protocol-http": "^5.0.1",
-						"@smithy/types": "^4.1.0",
-						"@smithy/util-stream": "^4.1.2",
+						"@smithy/core": "^3.8.0",
+						"@smithy/middleware-endpoint": "^4.1.18",
+						"@smithy/middleware-stack": "^4.0.5",
+						"@smithy/protocol-http": "^5.1.3",
+						"@smithy/types": "^4.3.2",
+						"@smithy/util-stream": "^4.2.4",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/types": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
-					"integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
+					"integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
 					"requires": {
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/url-parser": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
-					"integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.5.tgz",
+					"integrity": "sha512-j+733Um7f1/DXjYhCbvNXABV53NyCRRA54C7bNEIxNPs0YjfRxeMKjjgm2jvTYrciZyCjsicHwQ6Q0ylo+NAUw==",
 					"requires": {
-						"@smithy/querystring-parser": "^4.0.1",
-						"@smithy/types": "^4.1.0",
+						"@smithy/querystring-parser": "^4.0.5",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
@@ -36254,38 +37112,38 @@
 					}
 				},
 				"@smithy/util-defaults-mode-browser": {
-					"version": "4.0.7",
-					"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.7.tgz",
-					"integrity": "sha512-CZgDDrYHLv0RUElOsmZtAnp1pIjwDVCSuZWOPhIOBvG36RDfX1Q9+6lS61xBf+qqvHoqRjHxgINeQz47cYFC2Q==",
+					"version": "4.0.26",
+					"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.26.tgz",
+					"integrity": "sha512-xgl75aHIS/3rrGp7iTxQAOELYeyiwBu+eEgAk4xfKwJJ0L8VUjhO2shsDpeil54BOFsqmk5xfdesiewbUY5tKQ==",
 					"requires": {
-						"@smithy/property-provider": "^4.0.1",
-						"@smithy/smithy-client": "^4.1.6",
-						"@smithy/types": "^4.1.0",
+						"@smithy/property-provider": "^4.0.5",
+						"@smithy/smithy-client": "^4.4.10",
+						"@smithy/types": "^4.3.2",
 						"bowser": "^2.11.0",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/util-defaults-mode-node": {
-					"version": "4.0.7",
-					"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.7.tgz",
-					"integrity": "sha512-79fQW3hnfCdrfIi1soPbK3zmooRFnLpSx3Vxi6nUlqaaQeC5dm8plt4OTNDNqEEEDkvKghZSaoti684dQFVrGQ==",
+					"version": "4.0.26",
+					"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.26.tgz",
+					"integrity": "sha512-z81yyIkGiLLYVDetKTUeCZQ8x20EEzvQjrqJtb/mXnevLq2+w3XCEWTJ2pMp401b6BkEkHVfXb/cROBpVauLMQ==",
 					"requires": {
-						"@smithy/config-resolver": "^4.0.1",
-						"@smithy/credential-provider-imds": "^4.0.1",
-						"@smithy/node-config-provider": "^4.0.1",
-						"@smithy/property-provider": "^4.0.1",
-						"@smithy/smithy-client": "^4.1.6",
-						"@smithy/types": "^4.1.0",
+						"@smithy/config-resolver": "^4.1.5",
+						"@smithy/credential-provider-imds": "^4.0.7",
+						"@smithy/node-config-provider": "^4.1.4",
+						"@smithy/property-provider": "^4.0.5",
+						"@smithy/smithy-client": "^4.4.10",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/util-endpoints": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.1.tgz",
-					"integrity": "sha512-zVdUENQpdtn9jbpD9SCFK4+aSiavRb9BxEtw9ZGUR1TYo6bBHbIoi7VkrFQ0/RwZlzx0wRBaRmPclj8iAoJCLA==",
+					"version": "3.0.7",
+					"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.7.tgz",
+					"integrity": "sha512-klGBP+RpBp6V5JbrY2C/VKnHXn3d5V2YrifZbmMY8os7M6m8wdYFoO6w/fe5VkP+YVwrEktW3IWYaSQVNZJ8oQ==",
 					"requires": {
-						"@smithy/node-config-provider": "^4.0.1",
-						"@smithy/types": "^4.1.0",
+						"@smithy/node-config-provider": "^4.1.4",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
@@ -36298,32 +37156,32 @@
 					}
 				},
 				"@smithy/util-middleware": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
-					"integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.5.tgz",
+					"integrity": "sha512-N40PfqsZHRSsByGB81HhSo+uvMxEHT+9e255S53pfBw/wI6WKDI7Jw9oyu5tJTLwZzV5DsMha3ji8jk9dsHmQQ==",
 					"requires": {
-						"@smithy/types": "^4.1.0",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/util-retry": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.1.tgz",
-					"integrity": "sha512-WmRHqNVwn3kI3rKk1LsKcVgPBG6iLTBGC1iYOV3GQegwJ3E8yjzHytPt26VNzOWr1qu0xE03nK0Ug8S7T7oufw==",
+					"version": "4.0.7",
+					"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.7.tgz",
+					"integrity": "sha512-TTO6rt0ppK70alZpkjwy+3nQlTiqNfoXja+qwuAchIEAIoSZW8Qyd76dvBv3I5bCpE38APafG23Y/u270NspiQ==",
 					"requires": {
-						"@smithy/service-error-classification": "^4.0.1",
-						"@smithy/types": "^4.1.0",
+						"@smithy/service-error-classification": "^4.0.7",
+						"@smithy/types": "^4.3.2",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/util-stream": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.1.2.tgz",
-					"integrity": "sha512-44PKEqQ303d3rlQuiDpcCcu//hV8sn+u2JBo84dWCE0rvgeiVl0IlLMagbU++o0jCWhYCsHaAt9wZuZqNe05Hw==",
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.4.tgz",
+					"integrity": "sha512-vSKnvNZX2BXzl0U2RgCLOwWaAP9x/ddd/XobPK02pCbzRm5s55M53uwb1rl/Ts7RXZvdJZerPkA+en2FDghLuQ==",
 					"requires": {
-						"@smithy/fetch-http-handler": "^5.0.1",
-						"@smithy/node-http-handler": "^4.0.3",
-						"@smithy/types": "^4.1.0",
+						"@smithy/fetch-http-handler": "^5.1.1",
+						"@smithy/node-http-handler": "^4.1.1",
+						"@smithy/types": "^4.3.2",
 						"@smithy/util-base64": "^4.0.0",
 						"@smithy/util-buffer-from": "^4.0.0",
 						"@smithy/util-hex-encoding": "^4.0.0",
@@ -36347,6 +37205,19 @@
 						"@smithy/util-buffer-from": "^4.0.0",
 						"tslib": "^2.6.2"
 					}
+				},
+				"fast-xml-parser": {
+					"version": "5.2.5",
+					"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+					"integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+					"requires": {
+						"strnum": "^2.1.0"
+					}
+				},
+				"strnum": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+					"integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw=="
 				},
 				"tslib": {
 					"version": "2.8.1",
@@ -36465,6 +37336,59 @@
 				}
 			}
 		},
+		"@aws-sdk/util-format-url": {
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.873.0.tgz",
+			"integrity": "sha512-v//b9jFnhzTKKV3HFTw2MakdM22uBAs2lBov51BWmFXuFtSTdBLrR7zgfetQPE3PVkFai0cmtJQPdc3MX+T/cQ==",
+			"requires": {
+				"@aws-sdk/types": "3.862.0",
+				"@smithy/querystring-builder": "^4.0.5",
+				"@smithy/types": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"dependencies": {
+				"@aws-sdk/types": {
+					"version": "3.862.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.862.0.tgz",
+					"integrity": "sha512-Bei+RL0cDxxV+lW2UezLbCYYNeJm6Nzee0TpW0FfyTRBhH9C1XQh4+x+IClriXvgBnRquTMMYsmJfvx8iyLKrg==",
+					"requires": {
+						"@smithy/types": "^4.3.2",
+						"tslib": "^2.6.2"
+					}
+				},
+				"@smithy/querystring-builder": {
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.5.tgz",
+					"integrity": "sha512-NJeSCU57piZ56c+/wY+AbAw6rxCCAOZLCIniRE7wqvndqxcKKDOXzwWjrY7wGKEISfhL9gBbAaWWgHsUGedk+A==",
+					"requires": {
+						"@smithy/types": "^4.3.2",
+						"@smithy/util-uri-escape": "^4.0.0",
+						"tslib": "^2.6.2"
+					}
+				},
+				"@smithy/types": {
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
+					"integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
+					"requires": {
+						"tslib": "^2.6.2"
+					}
+				},
+				"@smithy/util-uri-escape": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
+					"integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+					"requires": {
+						"tslib": "^2.6.2"
+					}
+				},
+				"tslib": {
+					"version": "2.8.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+					"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+				}
+			}
+		},
 		"@aws-sdk/util-locate-window": {
 			"version": "3.568.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.568.0.tgz",
@@ -36540,6 +37464,30 @@
 				"tslib": "^2.3.1"
 			},
 			"dependencies": {
+				"tslib": {
+					"version": "2.8.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+					"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+				}
+			}
+		},
+		"@aws-sdk/xml-builder": {
+			"version": "3.873.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.873.0.tgz",
+			"integrity": "sha512-kLO7k7cGJ6KaHiExSJWojZurF7SnGMDHXRuQunFnEoD0n1yB6Lqy/S/zHiQ7oJnBhPr9q0TW9qFkrsZb1Uc54w==",
+			"requires": {
+				"@smithy/types": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"dependencies": {
+				"@smithy/types": {
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
+					"integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
+					"requires": {
+						"tslib": "^2.6.2"
+					}
+				},
 				"tslib": {
 					"version": "2.8.1",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -41666,19 +42614,19 @@
 			}
 		},
 		"@smithy/eventstream-serde-browser": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.0.3.tgz",
-			"integrity": "sha512-oe1d/tfCGVZBMX8O6HApaM4G+fF9JNdyLP7tWXt00epuL/kLOdp/4o9VqheLFeJaXgao+9IaBgs/q/oM48hxzg==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.0.5.tgz",
+			"integrity": "sha512-LCUQUVTbM6HFKzImYlSB9w4xafZmpdmZsOh9rIl7riPC3osCgGFVP+wwvYVw6pXda9PPT9TcEZxaq3XE81EdJQ==",
 			"requires": {
-				"@smithy/eventstream-serde-universal": "^4.0.3",
-				"@smithy/types": "^4.3.0",
+				"@smithy/eventstream-serde-universal": "^4.0.5",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"dependencies": {
 				"@smithy/types": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.0.tgz",
-					"integrity": "sha512-+1iaIQHthDh9yaLhRzaoQxRk+l9xlk+JjMFxGRhNLz+m9vKOkjNeU8QuB4w3xvzHyVR/BVlp/4AXDHjoRIkfgQ==",
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
+					"integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
 					"requires": {
 						"tslib": "^2.6.2"
 					}
@@ -41691,18 +42639,18 @@
 			}
 		},
 		"@smithy/eventstream-serde-config-resolver": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.1.1.tgz",
-			"integrity": "sha512-XXCPGjRNwpFWHKQJMKIjGLfFKYULYckFnxGcWmBC2mBf3NsrvUKgqHax4NCqc0TfbDAimPDHOc6HOKtzsXK9Gw==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.1.3.tgz",
+			"integrity": "sha512-yTTzw2jZjn/MbHu1pURbHdpjGbCuMHWncNBpJnQAPxOVnFUAbSIUSwafiphVDjNV93TdBJWmeVAds7yl5QCkcA==",
 			"requires": {
-				"@smithy/types": "^4.3.0",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"dependencies": {
 				"@smithy/types": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.0.tgz",
-					"integrity": "sha512-+1iaIQHthDh9yaLhRzaoQxRk+l9xlk+JjMFxGRhNLz+m9vKOkjNeU8QuB4w3xvzHyVR/BVlp/4AXDHjoRIkfgQ==",
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
+					"integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
 					"requires": {
 						"tslib": "^2.6.2"
 					}
@@ -41742,12 +42690,12 @@
 			}
 		},
 		"@smithy/eventstream-serde-universal": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.0.3.tgz",
-			"integrity": "sha512-ShOP512CZrYI9n+h64PJ84udzoNHUQtPddyh1j175KNTKsSnMEDNscOWJWyEoLQiuhWWw51lSa+k6ea9ZGXcRg==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.0.5.tgz",
+			"integrity": "sha512-JFnmu4SU36YYw3DIBVao3FsJh4Uw65vVDIqlWT4LzR6gXA0F3KP0IXFKKJrhaVzCBhAuMsrUUaT5I+/4ZhF7aw==",
 			"requires": {
-				"@smithy/eventstream-codec": "^4.0.3",
-				"@smithy/types": "^4.3.0",
+				"@smithy/eventstream-codec": "^4.0.5",
+				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"dependencies": {
@@ -41762,20 +42710,20 @@
 					}
 				},
 				"@smithy/eventstream-codec": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.0.3.tgz",
-					"integrity": "sha512-V22KIPXZsE2mc4zEgYGANM/7UbL9jWlOACEolyGyMuTY+jjHJ2PQ0FdopOTS1CS7u6PlAkALmypkv2oQ4aftcg==",
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.0.5.tgz",
+					"integrity": "sha512-miEUN+nz2UTNoRYRhRqVTJCx7jMeILdAurStT2XoS+mhokkmz1xAPp95DFW9Gxt4iF2VBqpeF9HbTQ3kY1viOA==",
 					"requires": {
 						"@aws-crypto/crc32": "5.2.0",
-						"@smithy/types": "^4.3.0",
+						"@smithy/types": "^4.3.2",
 						"@smithy/util-hex-encoding": "^4.0.0",
 						"tslib": "^2.6.2"
 					}
 				},
 				"@smithy/types": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.0.tgz",
-					"integrity": "sha512-+1iaIQHthDh9yaLhRzaoQxRk+l9xlk+JjMFxGRhNLz+m9vKOkjNeU8QuB4w3xvzHyVR/BVlp/4AXDHjoRIkfgQ==",
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
+					"integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
 					"requires": {
 						"tslib": "^2.6.2"
 					}

--- a/package.json
+++ b/package.json
@@ -386,7 +386,7 @@
 		"@anthropic-ai/bedrock-sdk": "^0.12.4",
 		"@anthropic-ai/sdk": "^0.37.0",
 		"@anthropic-ai/vertex-sdk": "^0.6.4",
-		"@aws-sdk/client-bedrock-runtime": "^3.758.0",
+		"@aws-sdk/client-bedrock-runtime": "^3.873.0",
 		"@bufbuild/protobuf": "^2.2.5",
 		"@google-cloud/vertexai": "^1.9.3",
 		"@google/genai": "^0.13.0",

--- a/proto/models.proto
+++ b/proto/models.proto
@@ -35,6 +35,27 @@ message VsCodeLmModel {
   string id = 4;
 }
 
+// Price tier for tiered pricing models
+message PriceTier {
+  int32 token_limit = 1;  // Upper limit (inclusive) of input tokens for this price
+  double price = 2;       // Price per million tokens for this tier
+}
+
+message ThinkingConfig {
+  optional int32 max_budget = 1;                    // Max allowed thinking budget tokens
+  optional double output_price = 2;                 // Output price per million tokens when budget > 0
+  repeated PriceTier output_price_tiers = 3;        // Optional: Tiered output price when budget > 0
+}
+
+// Model tier for tiered pricing structures
+message ModelTier {
+  int32 context_window = 1;
+  optional double input_price = 2;
+  optional double output_price = 3;
+  optional double cache_writes_price = 4;
+  optional double cache_reads_price = 5;
+}
+
 // For OpenRouterCompatibleModelInfo structure in OpenRouterModels
 message OpenRouterModelInfo {
   int32 max_tokens = 1;
@@ -46,6 +67,9 @@ message OpenRouterModelInfo {
   double cache_writes_price = 7;
   double cache_reads_price = 8;
   string description = 9;
+  optional ThinkingConfig thinking_config = 10;
+  optional bool supports_global_endpoint = 11;
+  repeated ModelTier tiers = 12;
 }
 
 // Shared response message for model information

--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -1,15 +1,23 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import { Stream as AnthropicStream } from "@anthropic-ai/sdk/streaming"
 import { withRetry } from "../retry"
-import { anthropicDefaultModelId, AnthropicModelId, anthropicModels, ApiHandlerOptions, ModelInfo } from "@shared/api"
+import { anthropicDefaultModelId, AnthropicModelId, anthropicModels, CLAUDE_SONNET_4_1M_SUFFIX, ModelInfo } from "@shared/api"
 import { ApiHandler } from "../index"
 import { ApiStream } from "../transform/stream"
 
+interface AnthropicHandlerOptions {
+	apiKey?: string
+	anthropicBaseUrl?: string
+	apiModelId?: string
+	thinkingBudgetTokens?: number
+	maxRetries?: number
+}
+
 export class AnthropicHandler implements ApiHandler {
-	private options: ApiHandlerOptions
+	private options: AnthropicHandlerOptions
 	private client: Anthropic
 
-	constructor(options: ApiHandlerOptions) {
+	constructor(options: AnthropicHandlerOptions) {
 		this.options = options
 		this.client = new Anthropic({
 			apiKey: this.options.apiKey,
@@ -22,7 +30,10 @@ export class AnthropicHandler implements ApiHandler {
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
 		const model = this.getModel()
 		let stream: AnthropicStream<Anthropic.RawMessageStreamEvent>
-		const modelId = model.id
+		const modelId = model.id.endsWith(CLAUDE_SONNET_4_1M_SUFFIX)
+			? model.id.slice(0, -CLAUDE_SONNET_4_1M_SUFFIX.length)
+			: model.id
+		const enable1mContextWindow = model.id.endsWith(CLAUDE_SONNET_4_1M_SUFFIX)
 
 		const budget_tokens = this.options.thinkingBudgetTokens || 0
 		const reasoningOn = (modelId.includes("3-7") || modelId.includes("4-")) && budget_tokens !== 0 ? true : false
@@ -95,24 +106,15 @@ export class AnthropicHandler implements ApiHandler {
 						stream: true,
 					},
 					(() => {
-						// prompt caching: https://x.com/alexalbert__/status/1823751995901272068
-						// https://github.com/anthropics/anthropic-sdk-typescript?tab=readme-ov-file#default-headers
-						// https://github.com/anthropics/anthropic-sdk-typescript/commit/c920b77fc67bd839bfeb6716ceab9d7c9bbe7393
-						switch (modelId) {
-							case "claude-sonnet-4-20250514":
-							case "claude-opus-4-20250514":
-							case "claude-3-7-sonnet-20250219":
-							case "claude-3-5-sonnet-20241022":
-							case "claude-3-5-haiku-20241022":
-							case "claude-3-opus-20240229":
-							case "claude-3-haiku-20240307":
-								return {
-									headers: {
-										"anthropic-beta": "prompt-caching-2024-07-31",
-									},
-								}
-							default:
-								return undefined
+						// 1m context window beta header
+						if (enable1mContextWindow) {
+							return {
+								headers: {
+									"anthropic-beta": "context-1m-2025-08-07",
+								},
+							}
+						} else {
+							return undefined
 						}
 					})(),
 				)

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -1,9 +1,8 @@
-import AnthropicBedrock from "@anthropic-ai/bedrock-sdk"
 import { Anthropic } from "@anthropic-ai/sdk"
 import { withRetry } from "../retry"
 import { ApiHandler } from "../"
 import { convertToR1Format } from "../transform/r1-format"
-import { ApiHandlerOptions, bedrockDefaultModelId, BedrockModelId, bedrockModels, ModelInfo } from "@shared/api"
+import { bedrockDefaultModelId, BedrockModelId, bedrockModels, CLAUDE_SONNET_4_1M_SUFFIX, ModelInfo } from "@shared/api"
 import { calculateApiCostOpenAI } from "../../utils/cost"
 import { ApiStream } from "../transform/stream"
 import { fromNodeProviderChain } from "@aws-sdk/credential-providers"
@@ -14,18 +13,118 @@ import {
 	InvokeModelWithResponseStreamCommand,
 } from "@aws-sdk/client-bedrock-runtime"
 
+// Import proper AWS SDK types
+import type { Message, ContentBlock } from "@aws-sdk/client-bedrock-runtime"
+
+interface AwsBedrockHandlerOptions {
+	apiModelId?: string
+	awsAccessKey?: string
+	awsSecretKey?: string
+	awsSessionToken?: string
+	awsRegion?: string
+	awsAuthentication?: string
+	awsBedrockApiKey?: string
+	awsUseCrossRegionInference?: boolean
+	awsBedrockUsePromptCache?: boolean
+	awsUseProfile?: boolean
+	awsProfile?: string
+	awsBedrockEndpoint?: string
+	awsBedrockCustomSelected?: boolean
+	awsBedrockCustomModelBaseId?: BedrockModelId
+	thinkingBudgetTokens?: number
+}
+
+// Extend AWS SDK types to include additionalModelResponseFields
+interface ExtendedMetadata {
+	usage?: {
+		inputTokens?: number
+		outputTokens?: number
+		cacheReadInputTokens?: number
+		cacheWriteInputTokens?: number
+	}
+	additionalModelResponseFields?: {
+		thinkingResponse?: {
+			reasoning?: Array<{
+				type: string
+				text?: string
+				signature?: string
+			}>
+		}
+	}
+}
+
+// Define types for stream response content blocks
+interface ContentBlockStart {
+	contentBlockIndex?: number
+	start?: {
+		type?: string
+		thinking?: string
+	}
+	contentBlock?: {
+		type?: string
+		thinking?: string
+	}
+	type?: string
+	thinking?: string
+}
+
+// Define types for stream response deltas
+interface ContentBlockDelta {
+	contentBlockIndex?: number
+	delta?: {
+		type?: string
+		thinking?: string
+		text?: string
+		reasoningContent?: {
+			text?: string
+		}
+	}
+}
+
+// Define types for supported content types
+type SupportedContentType = "text" | "image" | "thinking"
+
+interface ContentItem {
+	type: SupportedContentType
+	text?: string
+	source?: {
+		data: string | Buffer | Uint8Array
+		media_type?: string
+	}
+}
+
+// Define cache point type for AWS Bedrock
+interface CachePointContentBlock {
+	cachePoint: {
+		type: "default"
+	}
+}
+
+// Define provider options type based on AWS SDK patterns
+interface ProviderChainOptions {
+	ignoreCache?: boolean
+	profile?: string
+}
+
 // https://docs.anthropic.com/en/api/claude-on-amazon-bedrock
 export class AwsBedrockHandler implements ApiHandler {
-	private options: ApiHandlerOptions
+	private options: AwsBedrockHandlerOptions
 
-	constructor(options: ApiHandlerOptions) {
+	constructor(options: AwsBedrockHandlerOptions) {
 		this.options = options
 	}
 
-	@withRetry()
+	@withRetry({ maxRetries: 4 })
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
 		// cross region inference requires prefixing the model id with the region
-		const modelId = await this.getModelId()
+		const rawModelId = await this.getModelId()
+
+		const modelId = rawModelId.endsWith(CLAUDE_SONNET_4_1M_SUFFIX)
+			? rawModelId.slice(0, -CLAUDE_SONNET_4_1M_SUFFIX.length)
+			: rawModelId
+
+		const enable1mContextWindow = rawModelId.endsWith(CLAUDE_SONNET_4_1M_SUFFIX)
+
 		const model = this.getModel()
 
 		// This baseModelId is used to indicate the capabilities of the model.
@@ -46,146 +145,8 @@ export class AwsBedrockHandler implements ApiHandler {
 			return
 		}
 
-		const budget_tokens = this.options.thinkingBudgetTokens || 0
-		const reasoningOn =
-			(baseModelId.includes("3-7") || baseModelId.includes("sonnet-4") || baseModelId.includes("opus-4")) &&
-			budget_tokens !== 0
-				? true
-				: false
-
-		// Get model info and message indices for caching
-		const userMsgIndices = messages.reduce((acc, msg, index) => (msg.role === "user" ? [...acc, index] : acc), [] as number[])
-		const lastUserMsgIndex = userMsgIndices[userMsgIndices.length - 1] ?? -1
-		const secondLastMsgUserIndex = userMsgIndices[userMsgIndices.length - 2] ?? -1
-
-		// Create anthropic client, using sessions created or renewed after this handler's
-		// initialization, and allowing for session renewal if necessary as well
-		const client = await this.getAnthropicClient()
-
-		// Use withTempEnv to ensure environment variables are properly restored
-		const stream = await AwsBedrockHandler.withTempEnv(
-			() => {
-				// AWS SDK prioritizes AWS_PROFILE over AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY pair
-				// If this is set as an env variable already (ie. from ~/.zshrc) it will override credentials configured by Cline
-				// Temporarily remove AWS_PROFILE to ensure our credentials are used
-				delete process.env["AWS_PROFILE"]
-			},
-			async () => {
-				return await client.messages.create({
-					model: modelId,
-					max_tokens: model.info.maxTokens || 8192,
-					thinking: reasoningOn ? { type: "enabled", budget_tokens: budget_tokens } : undefined,
-					temperature: reasoningOn ? undefined : 0,
-					system: [
-						{
-							text: systemPrompt,
-							type: "text",
-							...(this.options.awsBedrockUsePromptCache === true && {
-								cache_control: { type: "ephemeral" },
-							}),
-						},
-					],
-					messages: messages.map((message, index) => {
-						if (index === lastUserMsgIndex || index === secondLastMsgUserIndex) {
-							return {
-								...message,
-								content:
-									typeof message.content === "string"
-										? [
-												{
-													type: "text",
-													text: message.content,
-													...(this.options.awsBedrockUsePromptCache === true && {
-														cache_control: { type: "ephemeral" },
-													}),
-												},
-											]
-										: message.content.map((content, contentIndex) =>
-												contentIndex === message.content.length - 1
-													? {
-															...content,
-															...(this.options.awsBedrockUsePromptCache === true && {
-																cache_control: { type: "ephemeral" },
-															}),
-														}
-													: content,
-											),
-							}
-						}
-						return message
-					}),
-					stream: true,
-				})
-			},
-		)
-
-		for await (const chunk of stream) {
-			switch (chunk.type) {
-				case "message_start":
-					const usage = chunk.message.usage
-					yield {
-						type: "usage",
-						inputTokens: usage.input_tokens || 0,
-						outputTokens: usage.output_tokens || 0,
-						cacheWriteTokens: usage.cache_creation_input_tokens || undefined,
-						cacheReadTokens: usage.cache_read_input_tokens || undefined,
-					}
-					break
-				case "message_delta":
-					yield {
-						type: "usage",
-						inputTokens: 0,
-						outputTokens: chunk.usage.output_tokens || 0,
-					}
-					break
-				case "content_block_start":
-					switch (chunk.content_block.type) {
-						case "thinking":
-							yield {
-								type: "reasoning",
-								reasoning: chunk.content_block.thinking || "",
-							}
-							break
-						case "redacted_thinking":
-							// Handle redacted thinking blocks - we still mark it as reasoning
-							// but note that the content is encrypted
-							yield {
-								type: "reasoning",
-								reasoning: "[Redacted thinking block]",
-							}
-							break
-						case "text":
-							if (chunk.index > 0) {
-								yield {
-									type: "text",
-									text: "\n",
-								}
-							}
-							yield {
-								type: "text",
-								text: chunk.content_block.text,
-							}
-							break
-					}
-					break
-				case "content_block_delta":
-					switch (chunk.delta.type) {
-						case "thinking_delta":
-							yield {
-								type: "reasoning",
-								reasoning: chunk.delta.thinking,
-							}
-							break
-						case "text_delta":
-							yield {
-								type: "text",
-								text: chunk.delta.text,
-							}
-							break
-					}
-					break
-			}
-		}
+		// Default: Use Anthropic Converse API for all Anthropic models
+		yield* this.createAnthropicMessage(systemPrompt, messages, modelId, model, enable1mContextWindow)
 	}
 
 	getModel(): { id: string; info: ModelInfo } {
@@ -197,11 +158,20 @@ export class AwsBedrockHandler implements ApiHandler {
 
 		const customSelected = this.options.awsBedrockCustomSelected
 		const baseModel = this.options.awsBedrockCustomModelBaseId
-		if (customSelected && modelId && baseModel && baseModel in bedrockModels) {
-			// Use the user-input model ID but inherit capabilities from the base model
+
+		// Handle custom models
+		if (customSelected && modelId) {
+			// If base model is provided and valid, use its capabilities
+			if (baseModel && baseModel in bedrockModels) {
+				return {
+					id: modelId,
+					info: bedrockModels[baseModel],
+				}
+			}
+			// For custom models without valid base model in bedrock model list, use default model's capabilities
 			return {
 				id: modelId,
-				info: bedrockModels[baseModel],
+				info: bedrockModels[bedrockDefaultModelId],
 			}
 		}
 
@@ -223,12 +193,26 @@ export class AwsBedrockHandler implements ApiHandler {
 		secretAccessKey: string
 		sessionToken?: string
 	}> {
+		// Configure provider options
+		const providerOptions: ProviderChainOptions = {}
+		const useProfile =
+			(this.options.awsAuthentication === undefined && this.options.awsUseProfile) ||
+			this.options.awsAuthentication === "profile"
+		if (useProfile) {
+			// For profile-based auth, always use ignoreCache to detect credential file changes
+			// This solves the AWS Identity Manager issue where credential files change externally
+			providerOptions.ignoreCache = true
+			if (this.options.awsProfile) {
+				providerOptions.profile = this.options.awsProfile
+			}
+		}
+
 		// Create AWS credentials by executing an AWS provider chain
-		const providerChain = fromNodeProviderChain()
+		const providerChain = fromNodeProviderChain(providerOptions)
 		return await AwsBedrockHandler.withTempEnv(
 			() => {
 				AwsBedrockHandler.setEnv("AWS_REGION", this.options.awsRegion)
-				if (this.options.awsUseProfile) {
+				if (useProfile) {
 					AwsBedrockHandler.setEnv("AWS_PROFILE", this.options.awsProfile)
 				} else {
 					delete process.env["AWS_PROFILE"]
@@ -252,43 +236,35 @@ export class AwsBedrockHandler implements ApiHandler {
 	 * Creates a BedrockRuntimeClient with the appropriate credentials
 	 */
 	private async getBedrockClient(): Promise<BedrockRuntimeClient> {
-		const credentials = await this.getAwsCredentials()
+		let auth: any
 
+		if (this.options.awsAuthentication === "apikey") {
+			auth = {
+				token: { token: this.options.awsBedrockApiKey },
+				authSchemePreference: ["httpBearerAuth"],
+			}
+		} else {
+			const credentials = await this.getAwsCredentials()
+			auth = {
+				credentials: {
+					accessKeyId: credentials.accessKeyId,
+					secretAccessKey: credentials.secretAccessKey,
+					sessionToken: credentials.sessionToken,
+				},
+			}
+		}
 		return new BedrockRuntimeClient({
 			region: this.getRegion(),
-			credentials: {
-				accessKeyId: credentials.accessKeyId,
-				secretAccessKey: credentials.secretAccessKey,
-				sessionToken: credentials.sessionToken,
-			},
+			...auth,
 			...(this.options.awsBedrockEndpoint && { endpoint: this.options.awsBedrockEndpoint }),
 		})
 	}
 
 	/**
-	 * Creates an AnthropicBedrock client with the appropriate credentials
-	 */
-	private async getAnthropicClient(): Promise<AnthropicBedrock> {
-		const credentials = await this.getAwsCredentials()
-
-		// Return an AnthropicBedrock client with the resolved/assumed credentials.
-		return new AnthropicBedrock({
-			awsAccessKey: credentials.accessKeyId,
-			awsSecretKey: credentials.secretAccessKey,
-			awsSessionToken: credentials.sessionToken,
-			awsRegion: this.getRegion(),
-			...(this.options.awsBedrockEndpoint && { baseURL: this.options.awsBedrockEndpoint }),
-		})
-	}
-
-	/**
 	 * Gets the appropriate model ID, accounting for cross-region inference if enabled.
-	 * If the model ID is an ARN that contains a slash, you will get the URL encoded ARN.
+	 * For custom models, returns the raw model ID without any encoding.
 	 */
 	async getModelId(): Promise<string> {
-		if (this.options.awsBedrockCustomSelected && this.getModel().id.includes("/")) {
-			return encodeURIComponent(this.getModel().id)
-		}
 		if (!this.options.awsBedrockCustomSelected && this.options.awsUseCrossRegionInference) {
 			const regionPrefix = this.getRegion().slice(0, 3)
 			switch (regionPrefix) {
@@ -525,126 +501,322 @@ export class AwsBedrockHandler implements ApiHandler {
 	}
 
 	/**
-	 * Creates a message using Amazon Nova models through AWS Bedrock
-	 * Implements support for Amazon Nova models
+	 * Executes a Converse API stream command and handles the response
+	 * Common implementation for both Anthropic and Nova models
 	 */
-	private async *createNovaMessage(
-		systemPrompt: string,
-		messages: Anthropic.Messages.MessageParam[],
-		modelId: string,
-		model: { id: string; info: ModelInfo },
-	): ApiStream {
-		// Get Bedrock client with proper credentials
-		const client = await this.getBedrockClient()
-
-		// Format messages for Nova model
-		const formattedMessages = this.formatNovaMessages(messages)
-
-		// Prepare request for Nova model
-		const command = new ConverseStreamCommand({
-			modelId: modelId,
-			messages: formattedMessages,
-			system: systemPrompt ? [{ text: systemPrompt }] : undefined,
-			inferenceConfig: {
-				maxTokens: model.info.maxTokens || 5000,
-				temperature: 0,
-				// topP: 0.9, // Alternative: use topP instead of temperature
-			},
-		})
-
-		// Execute the streaming request and handle response
+	private async *executeConverseStream(command: ConverseStreamCommand, modelInfo: ModelInfo): ApiStream {
 		try {
+			const client = await this.getBedrockClient()
 			const response = await client.send(command)
 
 			if (response.stream) {
-				let hasReportedInputTokens = false
+				// Buffer content by contentBlockIndex to handle multi-block responses correctly
+				const contentBuffers: Record<number, string> = {}
+				const blockTypes = new Map<number, "reasoning" | "text">()
 
 				for await (const chunk of response.stream) {
+					// Debug logging to see actual response structure
+					// console.log("Bedrock chunk:", JSON.stringify(chunk, null, 2))
+
+					// Handle thinking response in additionalModelResponseFields (LangChain format)
+					const metadata = chunk.metadata as ExtendedMetadata | undefined
+					if (metadata?.additionalModelResponseFields?.thinkingResponse) {
+						const thinkingResponse = metadata.additionalModelResponseFields.thinkingResponse
+						if (thinkingResponse.reasoning && Array.isArray(thinkingResponse.reasoning)) {
+							for (const reasoningBlock of thinkingResponse.reasoning) {
+								if (reasoningBlock.type === "text" && reasoningBlock.text) {
+									yield {
+										type: "reasoning",
+										reasoning: reasoningBlock.text,
+									}
+								}
+							}
+						}
+					}
+
 					// Handle metadata events with token usage information
 					if (chunk.metadata?.usage) {
-						// Report complete token usage from the model itself
 						const inputTokens = chunk.metadata.usage.inputTokens || 0
 						const outputTokens = chunk.metadata.usage.outputTokens || 0
+						const cacheReadInputTokens = chunk.metadata.usage.cacheReadInputTokens || 0
+						const cacheWriteInputTokens = chunk.metadata.usage.cacheWriteInputTokens || 0
+
 						yield {
 							type: "usage",
 							inputTokens,
 							outputTokens,
-							totalCost: calculateApiCostOpenAI(model.info, inputTokens, outputTokens, 0, 0),
-						}
-						hasReportedInputTokens = true
-					}
-
-					// Handle content delta (text generation)
-					if (chunk.contentBlockDelta?.delta?.text) {
-						yield {
-							type: "text",
-							text: chunk.contentBlockDelta.delta.text,
-						}
-					}
-
-					// Handle reasoning content if present
-					if (chunk.contentBlockDelta?.delta?.reasoningContent?.text) {
-						yield {
-							type: "reasoning",
-							reasoning: chunk.contentBlockDelta.delta.reasoningContent.text,
+							cacheReadTokens: cacheReadInputTokens,
+							cacheWriteTokens: cacheWriteInputTokens,
+							totalCost: calculateApiCostOpenAI(
+								modelInfo,
+								inputTokens,
+								outputTokens,
+								cacheWriteInputTokens,
+								cacheReadInputTokens,
+							),
 						}
 					}
 
-					// Handle errors
-					if (chunk.internalServerException) {
-						yield {
-							type: "text",
-							text: `[ERROR] Internal server error: ${chunk.internalServerException.message}`,
-						}
-					} else if (chunk.modelStreamErrorException) {
-						yield {
-							type: "text",
-							text: `[ERROR] Model stream error: ${chunk.modelStreamErrorException.message}`,
-						}
-					} else if (chunk.validationException) {
-						yield {
-							type: "text",
-							text: `[ERROR] Validation error: ${chunk.validationException.message}`,
-						}
-					} else if (chunk.throttlingException) {
-						yield {
-							type: "text",
-							text: `[ERROR] Throttling error: ${chunk.throttlingException.message}`,
-						}
-					} else if (chunk.serviceUnavailableException) {
-						yield {
-							type: "text",
-							text: `[ERROR] Service unavailable: ${chunk.serviceUnavailableException.message}`,
+					// Handle content block start - check if Bedrock uses Anthropic SDK format
+					if (chunk.contentBlockStart) {
+						const blockStart = chunk.contentBlockStart as ContentBlockStart
+						const blockIndex = chunk.contentBlockStart.contentBlockIndex
+
+						// Check for thinking block in various possible formats
+						if (
+							blockStart.start?.type === "thinking" ||
+							blockStart.contentBlock?.type === "thinking" ||
+							blockStart.type === "thinking"
+						) {
+							if (blockIndex !== undefined) {
+								blockTypes.set(blockIndex, "reasoning")
+								// Initialize content if provided
+								const initialContent =
+									blockStart.start?.thinking || blockStart.contentBlock?.thinking || blockStart.thinking || ""
+								if (initialContent) {
+									yield {
+										type: "reasoning",
+										reasoning: initialContent,
+									}
+								}
+							}
 						}
 					}
+
+					// Handle content block delta - accumulate content by block index
+					if (chunk.contentBlockDelta) {
+						const blockIndex = chunk.contentBlockDelta.contentBlockIndex
+
+						if (blockIndex !== undefined) {
+							// Initialize buffer for this block if it doesn't exist
+							if (!(blockIndex in contentBuffers)) {
+								contentBuffers[blockIndex] = ""
+							}
+
+							// Check if this is a thinking block
+							const blockType = blockTypes.get(blockIndex)
+							const delta = chunk.contentBlockDelta.delta as ContentBlockDelta["delta"]
+
+							// Handle thinking delta (Anthropic SDK format)
+							if (delta?.type === "thinking_delta" || delta?.thinking) {
+								const thinkingContent = delta.thinking || delta.text || ""
+								if (thinkingContent) {
+									yield {
+										type: "reasoning",
+										reasoning: thinkingContent,
+									}
+								}
+							} else if (delta?.reasoningContent?.text) {
+								// Handle reasoning content (Bedrock format)
+								const reasoningText = delta.reasoningContent.text
+								if (reasoningText) {
+									yield {
+										type: "reasoning",
+										reasoning: reasoningText,
+									}
+								}
+							} else if (chunk.contentBlockDelta.delta?.text) {
+								// Handle regular text content
+								const textContent = chunk.contentBlockDelta.delta.text
+								contentBuffers[blockIndex] += textContent
+
+								// Stream based on block type
+								if (blockType === "reasoning") {
+									yield {
+										type: "reasoning",
+										reasoning: textContent,
+									}
+								} else {
+									yield {
+										type: "text",
+										text: textContent,
+									}
+								}
+							}
+						}
+					}
+
+					// Handle content block stop - clean up buffers
+					if (chunk.contentBlockStop) {
+						const blockIndex = chunk.contentBlockStop.contentBlockIndex
+
+						if (blockIndex !== undefined) {
+							// Clean up buffers and tracking for this block
+							delete contentBuffers[blockIndex]
+							blockTypes.delete(blockIndex)
+						}
+					}
+
+					// Handle errors with unified error handling
+					yield* this.handleBedrockStreamError(chunk)
 				}
 			}
 		} catch (error) {
-			console.error("Error processing Nova model response:", error)
+			console.error("Error processing Converse API response:", error)
 			yield {
 				type: "text",
-				text: `[ERROR] Failed to process Nova response: ${error instanceof Error ? error.message : String(error)}`,
+				text: `[ERROR] Failed to process response: ${error instanceof Error ? error.message : String(error)}`,
 			}
 		}
 	}
 
 	/**
-	 * Formats messages for Amazon Nova models according to the SDK specification
+	 * Handles Bedrock stream errors in a unified way
 	 */
-	private formatNovaMessages(messages: Anthropic.Messages.MessageParam[]): { role: ConversationRole; content: any[] }[] {
+	private *handleBedrockStreamError(chunk: any): Generator<{ type: "text"; text: string }> {
+		if (chunk.internalServerException) {
+			yield {
+				type: "text",
+				text: `[ERROR] Internal server error: ${chunk.internalServerException.message}`,
+			}
+		} else if (chunk.modelStreamErrorException) {
+			yield {
+				type: "text",
+				text: `[ERROR] Model stream error: ${chunk.modelStreamErrorException.message}`,
+			}
+		} else if (chunk.validationException) {
+			yield {
+				type: "text",
+				text: `[ERROR] Validation error: ${chunk.validationException.message}`,
+			}
+		} else if (chunk.throttlingException) {
+			yield {
+				type: "text",
+				text: `[ERROR] Throttling error: ${chunk.throttlingException.message}`,
+			}
+		} else if (chunk.serviceUnavailableException) {
+			yield {
+				type: "text",
+				text: `[ERROR] Service unavailable: ${chunk.serviceUnavailableException.message}`,
+			}
+		}
+	}
+
+	/**
+	 * Prepares system messages with optional caching support
+	 */
+	private prepareSystemMessages(systemPrompt: string, enableCaching: boolean): any[] | undefined {
+		if (!systemPrompt) {
+			return undefined
+		}
+
+		if (enableCaching) {
+			return [{ text: systemPrompt }, { cachePoint: { type: "default" } }]
+		}
+
+		return [{ text: systemPrompt }]
+	}
+
+	/**
+	 * Gets inference configuration for different model types
+	 */
+	private getInferenceConfig(modelInfo: ModelInfo, modelType: "anthropic" | "nova"): any {
+		// For Anthropic models with thinking enabled, temperature must be 1
+		if (modelType === "anthropic") {
+			const budget_tokens = this.options.thinkingBudgetTokens || 0
+			const baseModelId =
+				(this.options.awsBedrockCustomSelected ? this.options.awsBedrockCustomModelBaseId : this.getModel().id) ||
+				this.getModel().id
+			const reasoningOn = this.shouldEnableReasoning(baseModelId, budget_tokens)
+
+			return {
+				maxTokens: modelInfo.maxTokens || 8192,
+				temperature: reasoningOn ? 1 : 0,
+			}
+		}
+
+		return {
+			maxTokens: modelInfo.maxTokens || (modelType === "nova" ? 5000 : 8192),
+			temperature: 0,
+		}
+	}
+
+	/**
+	 * Determines if reasoning should be enabled for Claude models
+	 */
+	private shouldEnableReasoning(baseModelId: string, budgetTokens: number): boolean {
+		return (
+			(baseModelId.includes("3-7") || baseModelId.includes("sonnet-4") || baseModelId.includes("opus-4")) &&
+			budgetTokens !== 0
+		)
+	}
+
+	/**
+	 * Creates a message using Anthropic Claude models through AWS Bedrock Converse API
+	 * Implements support for Anthropic Claude models using the unified Converse API
+	 */
+	private async *createAnthropicMessage(
+		systemPrompt: string,
+		messages: Anthropic.Messages.MessageParam[],
+		modelId: string,
+		model: { id: string; info: ModelInfo },
+		enable1mContextWindow: boolean,
+	): ApiStream {
+		// Format messages for Anthropic model using unified formatter
+		const formattedMessages = this.formatMessagesForConverseAPI(messages)
+
+		// Get model info and message indices for caching
+		const userMsgIndices = messages.reduce((acc, msg, index) => (msg.role === "user" ? [...acc, index] : acc), [] as number[])
+		const lastUserMsgIndex = userMsgIndices[userMsgIndices.length - 1] ?? -1
+		const secondLastMsgUserIndex = userMsgIndices[userMsgIndices.length - 2] ?? -1
+
+		// Apply caching controls to messages if enabled
+		const messagesWithCache = this.options.awsBedrockUsePromptCache
+			? this.applyCacheControlToMessages(formattedMessages, lastUserMsgIndex, secondLastMsgUserIndex)
+			: formattedMessages
+
+		// Prepare system message with caching support
+		const systemMessages = this.prepareSystemMessages(systemPrompt, this.options.awsBedrockUsePromptCache || false)
+
+		// Get thinking configuration
+		const budget_tokens = this.options.thinkingBudgetTokens || 0
+		const baseModelId =
+			(this.options.awsBedrockCustomSelected ? this.options.awsBedrockCustomModelBaseId : this.getModel().id) ||
+			this.getModel().id
+		const reasoningOn = this.shouldEnableReasoning(baseModelId, budget_tokens)
+
+		// Prepare request for Anthropic model using Converse API
+		const command = new ConverseStreamCommand({
+			modelId: modelId,
+			messages: messagesWithCache,
+			system: systemMessages,
+			inferenceConfig: this.getInferenceConfig(model.info, "anthropic"),
+			additionalModelRequestFields: {
+				// Add thinking configuration as per LangChain documentation
+				...(reasoningOn && {
+					thinking: {
+						type: "enabled",
+						budget_tokens: budget_tokens,
+					},
+				}),
+				...(enable1mContextWindow && {
+					anthropic_beta: ["context-1m-2025-08-07"],
+				}),
+			},
+		})
+
+		// Execute the streaming request using unified handler
+		yield* this.executeConverseStream(command, model.info)
+	}
+
+	/**
+	 * Formats messages for models using the Converse API specification
+	 * Used by both Anthropic and Nova models to avoid code duplication
+	 */
+	private formatMessagesForConverseAPI(messages: Anthropic.Messages.MessageParam[]): Message[] {
 		return messages.map((message) => {
 			// Determine role (user or assistant)
 			const role = message.role === "user" ? ConversationRole.USER : ConversationRole.ASSISTANT
 
 			// Process content based on type
-			let content: any[] = []
+			let content: ContentBlock[] = []
 
 			if (typeof message.content === "string") {
 				// Simple text content
 				content = [{ text: message.content }]
 			} else if (Array.isArray(message.content)) {
-				// Convert Anthropic content format to Nova content format
-				content = message.content
+				// Convert Anthropic content format to Converse API content format
+				const processedContent = message.content
 					.map((item) => {
 						// Text content
 						if (item.type === "text") {
@@ -653,55 +825,16 @@ export class AwsBedrockHandler implements ApiHandler {
 
 						// Image content
 						if (item.type === "image") {
-							// Handle different image source formats
-							let imageData: Uint8Array
-							let format = "jpeg" // default format
-
-							// Extract format from media_type if available
-							if (item.source.media_type) {
-								// Extract format from media_type (e.g., "image/jpeg" -> "jpeg")
-								const formatMatch = item.source.media_type.match(/image\/(\w+)/)
-								if (formatMatch && formatMatch[1]) {
-									format = formatMatch[1]
-									// Ensure format is one of the allowed values
-									if (!["png", "jpeg", "gif", "webp"].includes(format)) {
-										format = "jpeg" // Default to jpeg if not supported
-									}
-								}
-							}
-
-							// Get image data
-							try {
-								if (typeof item.source.data === "string") {
-									// Handle base64 encoded data
-									const base64Data = item.source.data.replace(/^data:image\/\w+;base64,/, "")
-									imageData = new Uint8Array(Buffer.from(base64Data, "base64"))
-								} else if (item.source.data && typeof item.source.data === "object") {
-									// Try to convert to Uint8Array
-									imageData = new Uint8Array(Buffer.from(item.source.data as any))
-								} else {
-									console.error("Unsupported image data format")
-									return null // Skip this item if format is not supported
-								}
-							} catch (error) {
-								console.error("Could not convert image data to Uint8Array:", error)
-								return null // Skip this item if conversion fails
-							}
-
-							return {
-								image: {
-									format,
-									source: {
-										bytes: imageData,
-									},
-								},
-							}
+							return this.processImageContent(item)
 						}
 
-						// Return null for unsupported content types
+						// Log unsupported content types for debugging
+						console.warn(`Unsupported content type: ${(item as ContentItem).type}`)
 						return null
 					})
-					.filter(Boolean) // Remove any null items
+					.filter((item): item is ContentBlock => item !== null)
+
+				content = processedContent
 			}
 
 			// Return formatted message
@@ -710,6 +843,131 @@ export class AwsBedrockHandler implements ApiHandler {
 				content,
 			}
 		})
+	}
+
+	/**
+	 * Processes image content with proper error handling and user notification
+	 */
+	private processImageContent(item: any): ContentBlock | null {
+		let imageData: Uint8Array
+		let format: "png" | "jpeg" | "gif" | "webp" = "jpeg" // default format
+
+		// Extract format from media_type if available
+		if (item.source.media_type) {
+			// Extract format from media_type (e.g., "image/jpeg" -> "jpeg")
+			const formatMatch = item.source.media_type.match(/image\/(\w+)/)
+			if (formatMatch && formatMatch[1]) {
+				const extractedFormat = formatMatch[1]
+				// Ensure format is one of the allowed values
+				if (["png", "jpeg", "gif", "webp"].includes(extractedFormat)) {
+					format = extractedFormat as "png" | "jpeg" | "gif" | "webp"
+				}
+			}
+		}
+
+		// Get image data with improved error handling
+		try {
+			if (typeof item.source.data === "string") {
+				// Handle base64 encoded data
+				const base64Data = item.source.data.replace(/^data:image\/\w+;base64,/, "")
+				imageData = new Uint8Array(Buffer.from(base64Data, "base64"))
+			} else if (item.source.data && typeof item.source.data === "object") {
+				// Try to convert to Uint8Array
+				imageData = item.source.data instanceof Uint8Array ? item.source.data : new Uint8Array(item.source.data)
+			} else {
+				throw new Error("Unsupported image data format")
+			}
+
+			return {
+				image: {
+					format,
+					source: {
+						bytes: imageData,
+					},
+				},
+			}
+		} catch (error) {
+			console.error("Failed to process image content:", error)
+			// Return a text content indicating the error instead of null
+			// This ensures users are aware of the issue
+			return {
+				text: `[ERROR: Failed to process image - ${error instanceof Error ? error.message : "Unknown error"}]`,
+			}
+		}
+	}
+
+	/**
+	 * Applies cache control to messages for prompt caching using AWS Bedrock's cachePoint system
+	 * AWS Bedrock uses cachePoint objects instead of Anthropic's cache_control approach
+	 */
+	private applyCacheControlToMessages(
+		messages: Message[],
+		lastUserMsgIndex: number,
+		secondLastMsgUserIndex: number,
+	): Message[] {
+		return messages.map((message, index) => {
+			// Add cachePoint to the last user message and second-to-last user message
+			if (index === lastUserMsgIndex || index === secondLastMsgUserIndex) {
+				// Clone the message to avoid modifying the original
+				const messageWithCache = { ...message }
+
+				if (messageWithCache.content && Array.isArray(messageWithCache.content)) {
+					// Add cachePoint to the end of the content array
+					messageWithCache.content = [
+						...messageWithCache.content,
+						{
+							cachePoint: {
+								type: "default",
+							},
+						} as CachePointContentBlock, // Properly typed cache point for AWS SDK
+					]
+				}
+
+				return messageWithCache
+			}
+
+			return message
+		})
+	}
+
+	/**
+	 * Creates a message using Amazon Nova models through AWS Bedrock
+	 * Implements support for Amazon Nova models with caching support
+	 */
+	private async *createNovaMessage(
+		systemPrompt: string,
+		messages: Anthropic.Messages.MessageParam[],
+		modelId: string,
+		model: { id: string; info: ModelInfo },
+	): ApiStream {
+		// Format messages for Nova model using unified formatter
+		const formattedMessages = this.formatMessagesForConverseAPI(messages)
+
+		// Get model info and message indices for caching (for Nova models that support it)
+		const userMsgIndices = messages.reduce((acc, msg, index) => (msg.role === "user" ? [...acc, index] : acc), [] as number[])
+		const lastUserMsgIndex = userMsgIndices[userMsgIndices.length - 1] ?? -1
+		const secondLastMsgUserIndex = userMsgIndices[userMsgIndices.length - 2] ?? -1
+
+		// Apply caching controls to messages if model supports caching and option is enabled
+		const messagesWithCache =
+			this.options.awsBedrockUsePromptCache && model.info.supportsPromptCache
+				? this.applyCacheControlToMessages(formattedMessages, lastUserMsgIndex, secondLastMsgUserIndex)
+				: formattedMessages
+
+		// Prepare system message with caching support for Nova models that support it
+		const enableCaching = this.options.awsBedrockUsePromptCache && model.info.supportsPromptCache
+		const systemMessages = this.prepareSystemMessages(systemPrompt, enableCaching || false)
+
+		// Prepare request for Nova model
+		const command = new ConverseStreamCommand({
+			modelId: modelId,
+			messages: messagesWithCache,
+			system: systemMessages,
+			inferenceConfig: this.getInferenceConfig(model.info, "nova"),
+		})
+
+		// Execute the streaming request using unified handler
+		yield* this.executeConverseStream(command, model.info)
 	}
 
 	async validateAPIKey(): Promise<boolean> {

--- a/src/api/transform/openrouter-stream.ts
+++ b/src/api/transform/openrouter-stream.ts
@@ -139,6 +139,8 @@ export async function createOpenRouterStream(
 		shouldApplyMiddleOutTransform = true
 	}
 
+	const isClaudeSonnet4 = model.id === "anthropic/claude-sonnet-4"
+
 	// @ts-ignore-next-line
 	const stream = await client.chat.completions.create({
 		model: model.id,
@@ -153,6 +155,8 @@ export async function createOpenRouterStream(
 		...(model.id.startsWith("openai/o") ? { reasoning_effort: reasoningEffort || "medium" } : {}),
 		...(reasoning ? { reasoning } : {}),
 		...(openRouterProviderSorting ? { provider: { sort: openRouterProviderSorting } } : {}),
+		// limit providers to only those that support the 1m context window
+		...(isClaudeSonnet4 ? { provider: { order: ["anthropic", "amazon-bedrock"], allow_fallbacks: false } } : {}),
 	})
 
 	return stream

--- a/src/core/controller/models/refreshOpenRouterModels.ts
+++ b/src/core/controller/models/refreshOpenRouterModels.ts
@@ -6,6 +6,7 @@ import path from "path"
 import fs from "fs/promises"
 import { fileExistsAtPath } from "@utils/fs"
 import { GlobalFileNames } from "@core/storage/disk"
+import { CLAUDE_SONNET_4_1M_TIERS } from "@/shared/api"
 
 /**
  * Refreshes the OpenRouter models and returns the updated model list
@@ -41,10 +42,14 @@ export async function refreshOpenRouterModels(
 					outputPrice: parsePrice(rawModel.pricing?.completion),
 					description: rawModel.description,
 				}
-
 				switch (rawModel.id) {
 					case "anthropic/claude-sonnet-4":
-					case "anthropic/claude-opus-4":
+						modelInfo.supportsPromptCache = true
+						modelInfo.cacheWritesPrice = 3.75
+						modelInfo.cacheReadsPrice = 0.3
+						modelInfo.contextWindow = 1_000_000 // limiting providers to those that support 1m context window
+						modelInfo.tiers = CLAUDE_SONNET_4_1M_TIERS
+						break
 					case "anthropic/claude-3-7-sonnet":
 					case "anthropic/claude-3-7-sonnet:beta":
 					case "anthropic/claude-3.7-sonnet":
@@ -56,6 +61,12 @@ export async function refreshOpenRouterModels(
 						modelInfo.supportsPromptCache = true
 						modelInfo.cacheWritesPrice = 3.75
 						modelInfo.cacheReadsPrice = 0.3
+						break
+					case "anthropic/claude-opus-4.1":
+					case "anthropic/claude-opus-4":
+						modelInfo.supportsPromptCache = true
+						modelInfo.cacheWritesPrice = 18.75
+						modelInfo.cacheReadsPrice = 1.5
 						break
 					case "anthropic/claude-3.5-sonnet-20240620":
 					case "anthropic/claude-3.5-sonnet-20240620:beta":
@@ -93,6 +104,23 @@ export async function refreshOpenRouterModels(
 						modelInfo.inputPrice = 0
 						modelInfo.cacheWritesPrice = 0.14
 						modelInfo.cacheReadsPrice = 0.014
+						break
+					case "x-ai/grok-3-beta":
+						modelInfo.supportsPromptCache = true
+						modelInfo.cacheWritesPrice = 0.75
+						modelInfo.cacheReadsPrice = 0
+						break
+					case "moonshotai/kimi-k2":
+						// forcing kimi-k2 to use the together provider for full context and best throughput
+						modelInfo.inputPrice = 1
+						modelInfo.outputPrice = 3
+						modelInfo.contextWindow = 131_000
+						break
+					case "openai/gpt-5":
+					case "openai/gpt-5-chat":
+					case "openai/gpt-5-mini":
+					case "openai/gpt-5-nano":
+						modelInfo.maxTokens = 8_192 // 128000 breaks context window truncation
 						break
 					default:
 						if (rawModel.id.startsWith("openai/")) {
@@ -143,6 +171,7 @@ export async function refreshOpenRouterModels(
 			cacheWritesPrice: model.cacheWritesPrice ?? 0,
 			cacheReadsPrice: model.cacheReadsPrice ?? 0,
 			description: model.description ?? "",
+			tiers: model.tiers ?? [],
 		}
 	}
 

--- a/src/core/controller/models/refreshRequestyModels.ts
+++ b/src/core/controller/models/refreshRequestyModels.ts
@@ -40,6 +40,7 @@ export async function refreshRequestyModels(
 					cacheWritesPrice: parsePrice(model.caching_price) || 0,
 					cacheReadsPrice: parsePrice(model.cached_price) || 0,
 					description: model.description,
+					tiers: model.tiers || [],
 				}
 				models[model.id] = modelInfo
 			}

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -136,11 +136,40 @@ export interface OpenAiCompatibleModelInfo extends ModelInfo {
 	isR1FormatRequired?: boolean
 }
 
+export const CLAUDE_SONNET_4_1M_SUFFIX = ":1m"
+export const CLAUDE_SONNET_4_1M_TIERS = [
+	{
+		contextWindow: 200000,
+		inputPrice: 3.0,
+		outputPrice: 15,
+		cacheWritesPrice: 3.75,
+		cacheReadsPrice: 0.3,
+	},
+	{
+		contextWindow: Number.MAX_SAFE_INTEGER, // storing infinity in vs storage is not possible, it converts to 'null', which causes crash in webview ModelInfoView
+		inputPrice: 6,
+		outputPrice: 22.5,
+		cacheWritesPrice: 7.5,
+		cacheReadsPrice: 0.6,
+	},
+]
+
 // Anthropic
 // https://docs.anthropic.com/en/docs/about-claude/models // prices updated 2025-01-02
 export type AnthropicModelId = keyof typeof anthropicModels
 export const anthropicDefaultModelId: AnthropicModelId = "claude-sonnet-4-20250514"
 export const anthropicModels = {
+	"claude-sonnet-4-20250514:1m": {
+		maxTokens: 8192,
+		contextWindow: 1_000_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 3.0,
+		outputPrice: 15.0,
+		cacheWritesPrice: 3.75,
+		cacheReadsPrice: 0.3,
+		tiers: CLAUDE_SONNET_4_1M_TIERS,
+	},
 	"claude-sonnet-4-20250514": {
 		maxTokens: 8192,
 		contextWindow: 200_000,
@@ -219,6 +248,17 @@ export const anthropicModels = {
 export type BedrockModelId = keyof typeof bedrockModels
 export const bedrockDefaultModelId: BedrockModelId = "anthropic.claude-sonnet-4-20250514-v1:0"
 export const bedrockModels = {
+	"anthropic.claude-sonnet-4-20250514-v1:0:1m": {
+		maxTokens: 8192,
+		contextWindow: 1_000_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 3.0,
+		outputPrice: 15.0,
+		cacheWritesPrice: 3.75,
+		cacheReadsPrice: 0.3,
+		tiers: CLAUDE_SONNET_4_1M_TIERS,
+	},
 	"anthropic.claude-sonnet-4-20250514-v1:0": {
 		maxTokens: 8192,
 		contextWindow: 200_000,
@@ -358,13 +398,14 @@ export const bedrockModels = {
 export const openRouterDefaultModelId = "anthropic/claude-sonnet-4" // will always exist in openRouterModels
 export const openRouterDefaultModelInfo: ModelInfo = {
 	maxTokens: 8192,
-	contextWindow: 200_000,
+	contextWindow: 1_000_000,
 	supportsImages: true,
 	supportsPromptCache: true,
 	inputPrice: 3.0,
 	outputPrice: 15.0,
 	cacheWritesPrice: 3.75,
 	cacheReadsPrice: 0.3,
+	tiers: CLAUDE_SONNET_4_1M_TIERS,
 	description:
 		"Claude 4 Sonnet is an advanced large language model with improved reasoning, coding, and problem-solving capabilities. It introduces a hybrid reasoning approach, allowing users to choose between rapid responses and extended, step-by-step processing for complex tasks. The model demonstrates notable improvements in coding, particularly in front-end development and full-stack updates, and excels in agentic workflows, where it can autonomously navigate multi-step processes. \n\nClaude 4 Sonnet maintains performance parity with its predecessor in standard mode while offering an extended reasoning mode for enhanced accuracy in math, coding, and instruction-following tasks.\n\nRead more at the [blog post here](https://www.anthropic.com/news/claude-4)",
 }

--- a/src/utils/cost.ts
+++ b/src/utils/cost.ts
@@ -81,7 +81,7 @@ export function calculateApiCostAnthropic(
 		outputTokens,
 		cacheCreationInputTokensNum,
 		cacheReadInputTokensNum,
-		inputTokens,
+		inputTokens + cacheCreationInputTokensNum + cacheReadInputTokensNum, // used for tiered price lookup
 		thinkingBudgetTokens,
 	)
 }

--- a/webview-ui/src/components/chat/Announcement.tsx
+++ b/webview-ui/src/components/chat/Announcement.tsx
@@ -42,19 +42,12 @@ const Announcement = ({ version, hideAnnouncement }: AnnouncementProps) => {
 			<h3 style={h3TitleStyle}>
 				🎉{"  "}New in v{minorVersion}
 			</h3>
-			<ul style={ulStyle}>
-				<li>
-					<b>Claude 4 Models:</b> Now with support for Anthropic Claude Sonnet 4 and Claude Opus 4 in both Anthropic and
-					Vertex providers.
-				</li>
-				<li>
-					<b>New Settings Page:</b> Redesigned settings, now split into tabs for easier navigation and a cleaner
-					experience.
-				</li>
-				<li>
-					<b>Nebius AI Studio:</b> Added Nebius AI Studio as a new provider. (Thanks @Aktsvigun!)
-				</li>
-			</ul>
+			<b>1M Context Window:</b> Claude Sonnet 4 now supports a 1 million token context window to handle larger codebases and
+			more complex tasks. Cline/OpenRouter users get instant access, Anthropic users with Tier 4 access can select the{" "}
+			<code>
+				claude-sonnet-4-20250514<b>:1m</b>
+			</code>{" "}
+			model.
 			<Accordion isCompact className="pl-0">
 				<AccordionItem
 					key="1"

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -54,6 +54,7 @@ import {
 	doubaoModels,
 	doubaoDefaultModelId,
 	liteLlmModelInfoSaneDefaults,
+	CLAUDE_SONNET_4_1M_SUFFIX,
 } from "@shared/api"
 import { ExtensionMessage } from "@shared/ExtensionMessage"
 import { useExtensionState } from "@/context/ExtensionStateContext"
@@ -948,11 +949,15 @@ const ApiOptions = ({
 					)}
 					{(selectedModelId === "anthropic.claude-3-7-sonnet-20250219-v1:0" ||
 						selectedModelId === "anthropic.claude-sonnet-4-20250514-v1:0" ||
+						selectedModelId === `anthropic.claude-sonnet-4-20250514-v1:0${CLAUDE_SONNET_4_1M_SUFFIX}` ||
 						selectedModelId === "anthropic.claude-opus-4-20250514-v1:0" ||
 						(apiConfiguration?.awsBedrockCustomSelected &&
 							apiConfiguration?.awsBedrockCustomModelBaseId === "anthropic.claude-3-7-sonnet-20250219-v1:0") ||
 						(apiConfiguration?.awsBedrockCustomSelected &&
 							apiConfiguration?.awsBedrockCustomModelBaseId === "anthropic.claude-sonnet-4-20250514-v1:0") ||
+						(apiConfiguration?.awsBedrockCustomSelected &&
+							apiConfiguration?.awsBedrockCustomModelBaseId ===
+								`anthropic.claude-sonnet-4-20250514-v1:0${CLAUDE_SONNET_4_1M_SUFFIX}`) ||
 						(apiConfiguration?.awsBedrockCustomSelected &&
 							apiConfiguration?.awsBedrockCustomModelBaseId === "anthropic.claude-opus-4-20250514-v1:0")) && (
 						<ThinkingBudgetSlider apiConfiguration={apiConfiguration} setApiConfiguration={setApiConfiguration} />
@@ -2279,13 +2284,13 @@ const formatTiers = (
 			return (
 				<span style={{ paddingLeft: "15px" }} key={index}>
 					{formatPrice(price)}/million tokens (
-					{tier.contextWindow === Number.POSITIVE_INFINITY ? (
+					{tier.contextWindow === Number.POSITIVE_INFINITY || tier.contextWindow >= Number.MAX_SAFE_INTEGER ? (
 						<span>
 							{">"} {prevLimit.toLocaleString()}
 						</span>
 					) : (
 						<span>
-							{"<="} {tier.contextWindow.toLocaleString()}
+							{"<="} {tier.contextWindow?.toLocaleString()}
 						</span>
 					)}
 					{" tokens)"}


### PR DESCRIPTION
### Description

- Enhanced support for Claude Sonnet 4, extending its maximum context window to 1 million tokens and enabling tiered pricing for more flexible usage models.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)