### PR TITLE
fix: Set zIndex for DropdownContainer in BedrockEmbeddingProvider and initialize langfuse during extension activation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -127,6 +127,9 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	telemetryService.captureExtensionActivated(installId)
 
+	// Update telemetry configuration during extension activation
+	await sidebarWebview.controller.updateTelemetryConfig()
+
 	context.subscriptions.push(
 		vscode.commands.registerCommand("hai.plusButtonClicked", async (webview: any) => {
 			console.log("[DEBUG] plusButtonClicked", webview)

--- a/src/services/posthog/telemetry/TelemetryService.ts
+++ b/src/services/posthog/telemetry/TelemetryService.ts
@@ -13,7 +13,7 @@ import { getGitUserInfo } from "@/utils/git"
 import { HaiConfig } from "@/shared/hai-config"
 
 /**
- * TelemetryService handles telemetry event tracking for the Cline extension
+ * TelemetryService handles telemetry event tracking for the HAI extension
  * Uses PostHog analytics to track user interactions and system events
  * Respects user privacy settings and VSCode's global telemetry configuration
  */

--- a/webview-ui/src/components/settings/providers/embedding/BedrockEmbeddingProvider.tsx
+++ b/webview-ui/src/components/settings/providers/embedding/BedrockEmbeddingProvider.tsx
@@ -41,7 +41,7 @@ export const BedrockEmbeddingProvider = ({ showModelOptions, isPopup }: BedrockE
 				<span style={{ fontWeight: 500 }}>AWS Session Token (optional)</span>
 			</DebouncedTextField>
 
-			<DropdownContainer>
+			<DropdownContainer zIndex={1001}>
 				<label htmlFor="embedding-aws-region">
 					<span style={{ fontWeight: 500 }}>
 						AWS Region <span style={{ color: "var(--vscode-errorForeground)" }}>*</span>

--- a/webview-ui/src/components/settings/sections/AboutSection.tsx
+++ b/webview-ui/src/components/settings/sections/AboutSection.tsx
@@ -14,8 +14,8 @@ const AboutSection = ({ version, renderSectionHeader }: AboutSectionProps) => {
 				<div className="text-center text-[var(--vscode-descriptionForeground)] text-xs leading-[1.2] px-0 py-0 pr-2 pb-[15px] mt-auto">
 					<p className="break-words m-0 p-0">
 						If you have any questions or feedback, feel free to open an issue at{" "}
-						<VSCodeLink href="https://github.com/cline/cline" className="inline">
-							https://github.com/cline/cline
+						<VSCodeLink href="https://github.com/presidio-oss/cline-based-code-generator" className="inline">
+							https://github.com/presidio-oss/cline-based-code-generator
 						</VSCodeLink>
 					</p>
 					<p className="italic mt-[10px] mb-0 p-0">v{version}</p>


### PR DESCRIPTION
### Description

- Fix dropdown layering issues in BedrockEmbeddingProvider by setting an appropriate zIndex on DropdownContainer.
- Initialize langfuse during extension activation

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [ ] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix, or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [ ] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)