### PR TITLE
feat: Enhance Claude Sonnet 4.5 support with 1M context window and tiered pricing

### DIFF
--- a/.changeset/kind-games-remain.md
+++ b/.changeset/kind-games-remain.md
@@ -1,0 +1,5 @@
+---
+"hai-build-code-generator": patch
+---
+
+Enhanced support for Claude Sonnet 4.5, extending its maximum context window to 1 million tokens and enabling tiered pricing for more flexible usage models.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,7 +5,7 @@ body:
     - type: markdown
       attributes:
           value: |
-              **Important:** All bug reports must be reproducible using Claude 4 Sonnet. HAI uses complex prompts so less capable models may not work as expected.
+              **Important:** All bug reports must be reproducible using Claude Sonnet 4.5. HAI uses complex prompts so less capable models may not work as expected.
     - type: textarea
       id: what-happened
       attributes:
@@ -36,7 +36,7 @@ body:
       attributes:
           label: Provider/Model
           description: What provider and model were you using when the issue occurred?
-          placeholder: "e.g., anthropic/claude-3.7-sonnet, gemini:gemini-2.5-pro-exp-03-25"
+          placeholder: "e.g., anthropic/claude-sonnet-4.5, gemini:gemini-2.5-pro-exp-03-25"
       validations:
           required: true
     - type: textarea

--- a/hai-docs/getting-started/model-selection-guide.mdx
+++ b/hai-docs/getting-started/model-selection-guide.mdx
@@ -9,7 +9,7 @@ New models drop constantly, so this guide focuses on what's working well with HA
 
 | Model | Context Window | Input Price* | Output Price* | Best For |
 |-------|---------------|--------------|---------------|----------|
-| **Claude Sonnet 4** | 1M tokens | $3-6 | $15-22.50 | Reliable tool usage, complex codebases |
+| **Claude Sonnet 4.5** | 1M tokens | $3-6 | $15-22.50 | Reliable tool usage, complex codebases |
 | **Qwen3 Coder** | 256K tokens | $0.20 | $0.80 | Coding tasks, open source flexibility |
 | **Gemini 2.5 Pro** | 1M+ tokens | TBD | TBD | Large codebases, document analysis |
 | **GPT-5** | 400K tokens | $1.25 | $10 | Latest OpenAI tech, three modes |
@@ -57,9 +57,9 @@ New models drop constantly, so this guide focuses on what's working well with HA
 
 | If you want... | Use this |
 |----------------|----------|
-| Something that just works | Claude Sonnet 4 |
+| Something that just works | Claude Sonnet 4.5 |
 | To save money | DeepSeek V3 or Qwen3 variants |
-| Huge context windows | Gemini 2.5 Pro or Claude Sonnet 4 |
+| Huge context windows | Gemini 2.5 Pro or Claude Sonnet 4.5 |
 | Open source | Qwen3 Coder, Z AI GLM 4.5, or Kimi K2 |
 | Latest tech | GPT-5 |
 | Speed | Qwen3 Coder on Cerebras (fastest available) |
@@ -71,6 +71,6 @@ HAI automatically handles context limits with [auto-compact](/features/auto-comp
 
 ## The Bottom Line
 
-Start with **Claude Sonnet 4** if you want reliability. Experiment with **open source options** once you're comfortable to find the best fit for your workflow and budget.
+Start with **Claude Sonnet 4.5** if you want reliability. Experiment with **open source options** once you're comfortable to find the best fit for your workflow and budget.
 
 The landscape moves fast - these recommendations reflect what's working now, but keep an eye on new releases.

--- a/hai-docs/getting-started/understanding-context-management.mdx
+++ b/hai-docs/getting-started/understanding-context-management.mdx
@@ -53,7 +53,7 @@ Think of context like a whiteboard you and HAI share:
 -   **Context Window** is the size of the whiteboard itself:
     -   Measured in tokens (1 token ≈ 3/4 of an English word)
     -   Each model has a fixed size:
-        -   Claude Sonnet 4: 1,000,000 tokens
+        -   Claude Sonnet 4.5: 1,000,000 tokens
         -   Qwen3 Coder: 256,000 tokens
         -   Gemini 2.5 Pro: 1,000,000+ tokens
         -   GPT-5: 400,000 tokens
@@ -77,7 +77,7 @@ HAI provides a visual way to monitor your context window usage through a progres
 -   ↑ shows input tokens (what you've sent to the LLM)
 -   ↓ shows output tokens (what the LLM has generated)
 -   The progress bar visualizes how much of your context window you've used
--   The total shows your model's maximum capacity (e.g., 1M for Claude Sonnet 4)
+-   The total shows your model's maximum capacity (e.g., 1M for Claude Sonnet 4.5)
 
 ### When to Watch the Bar
 

--- a/hai-docs/provider-config/anthropic.mdx
+++ b/hai-docs/provider-config/anthropic.mdx
@@ -17,11 +17,8 @@ description: "Learn how to configure and use Anthropic Claude models with HAI. C
 HAI supports the following Anthropic Claude models:
 
 - `claude-opus-4-20250514`
-- `claude-opus-4-20250514:thinking` (Extended Thinking variant)
-- `claude-sonnet-4-20250514` (Recommended)
-- `claude-sonnet-4-20250514:thinking` (Extended Thinking variant)
+- `anthropic/claude-sonnet-4.5` (Recommended)
 - `claude-3-7-sonnet-20250219`
-- `claude-3-7-sonnet-20250219:thinking` (Extended Thinking variant)
 - `claude-3-5-sonnet-20241022`
 - `claude-3-5-haiku-20241022`
 - `claude-3-opus-20240229`
@@ -46,8 +43,8 @@ HAI users can leverage this by checking the `Enable Extended Thinking` box below
 
 **Key Aspects of Extended Thinking:**
 
-- **Supported Models:** This feature is available for select models, including variants of Claude Opus 4, Claude Sonnet 4, and Claude Sonnet 3.7. The specific models listed in the "Supported Models" section above with the `:thinking` suffix are pre-configured in HAI to utilize this.
-- **Summarized Thinking (Claude 4):** For Claude 4 models, the API returns a summary of the full thinking process to balance insight with efficiency and prevent misuse. You are billed for the full thinking tokens, not just the summary.
+- **Supported Models:** This feature is available for select models, including Claude Opus 4, Claude Sonnet 4.5, and Claude Sonnet 3.7.
+- **Summarized Thinking (Claude 4):** For Claude 4 and 4.5 models, the API returns a summary of the full thinking process to balance insight with efficiency and prevent misuse. You are billed for the full thinking tokens, not just the summary.
 - **Streaming:** Extended thinking responses, including the `thinking` blocks, can be streamed.
 - **Tool Use & Prompt Caching:** Extended thinking interacts with tool use (requiring thinking blocks to be passed back) and prompt caching (with specific behaviors around cache invalidation and context).
 

--- a/src/core/api/providers/anthropic.ts
+++ b/src/core/api/providers/anthropic.ts
@@ -1,6 +1,6 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import { Stream as AnthropicStream } from "@anthropic-ai/sdk/streaming"
-import { AnthropicModelId, anthropicDefaultModelId, anthropicModels, CLAUDE_SONNET_4_1M_SUFFIX, ModelInfo } from "@shared/api"
+import { AnthropicModelId, anthropicDefaultModelId, anthropicModels, CLAUDE_SONNET_1M_SUFFIX, ModelInfo } from "@shared/api"
 import { ApiHandler, CommonApiHandlerOptions } from "../index"
 import { withRetry } from "../retry"
 import { ApiStream } from "../transform/stream"
@@ -45,16 +45,18 @@ export class AnthropicHandler implements ApiHandler {
 		const model = this.getModel()
 		let stream: AnthropicStream<Anthropic.RawMessageStreamEvent>
 
-		const modelId = model.id.endsWith(CLAUDE_SONNET_4_1M_SUFFIX)
-			? model.id.slice(0, -CLAUDE_SONNET_4_1M_SUFFIX.length)
-			: model.id
-		const enable1mContextWindow = model.id.endsWith(CLAUDE_SONNET_4_1M_SUFFIX)
+		const modelId = model.id.endsWith(CLAUDE_SONNET_1M_SUFFIX) ? model.id.slice(0, -CLAUDE_SONNET_1M_SUFFIX.length) : model.id
+		const enable1mContextWindow = model.id.endsWith(CLAUDE_SONNET_1M_SUFFIX)
 
 		const budget_tokens = this.options.thinkingBudgetTokens || 0
-		const reasoningOn = !!((modelId.includes("3-7") || modelId.includes("4-")) && budget_tokens !== 0)
+		const reasoningOn = !!(
+			(modelId.includes("3-7") || modelId.includes("4-") || modelId.includes("4-5")) &&
+			budget_tokens !== 0
+		)
 
 		switch (modelId) {
 			// 'latest' alias does not support cache_control
+			case "claude-sonnet-4-5-20250929":
 			case "claude-sonnet-4-20250514":
 			case "claude-3-7-sonnet-20250219":
 			case "claude-3-5-sonnet-20241022":

--- a/src/core/api/providers/bedrock.ts
+++ b/src/core/api/providers/bedrock.ts
@@ -9,7 +9,7 @@ import {
 	InvokeModelWithResponseStreamCommand,
 } from "@aws-sdk/client-bedrock-runtime"
 import { fromNodeProviderChain } from "@aws-sdk/credential-providers"
-import { BedrockModelId, bedrockDefaultModelId, bedrockModels, CLAUDE_SONNET_4_1M_SUFFIX, ModelInfo } from "@shared/api"
+import { BedrockModelId, bedrockDefaultModelId, bedrockModels, CLAUDE_SONNET_1M_SUFFIX, ModelInfo } from "@shared/api"
 import { calculateApiCostOpenAI } from "@utils/cost"
 import { ApiHandler, CommonApiHandlerOptions } from "../"
 import { withRetry } from "../retry"
@@ -119,11 +119,11 @@ export class AwsBedrockHandler implements ApiHandler {
 		// cross region inference requires prefixing the model id with the region
 		const rawModelId = await this.getModelId()
 
-		const modelId = rawModelId.endsWith(CLAUDE_SONNET_4_1M_SUFFIX)
-			? rawModelId.slice(0, -CLAUDE_SONNET_4_1M_SUFFIX.length)
+		const modelId = rawModelId.endsWith(CLAUDE_SONNET_1M_SUFFIX)
+			? rawModelId.slice(0, -CLAUDE_SONNET_1M_SUFFIX.length)
 			: rawModelId
 
-		const enable1mContextWindow = rawModelId.endsWith(CLAUDE_SONNET_4_1M_SUFFIX)
+		const enable1mContextWindow = rawModelId.endsWith(CLAUDE_SONNET_1M_SUFFIX)
 
 		const model = this.getModel()
 
@@ -741,7 +741,10 @@ export class AwsBedrockHandler implements ApiHandler {
 	 */
 	private shouldEnableReasoning(baseModelId: string, budgetTokens: number): boolean {
 		return (
-			(baseModelId.includes("3-7") || baseModelId.includes("sonnet-4") || baseModelId.includes("opus-4")) &&
+			(baseModelId.includes("3-7") ||
+				baseModelId.includes("sonnet-4") ||
+				baseModelId.includes("opus-4") ||
+				baseModelId.includes("sonnet-4-5")) &&
 			budgetTokens !== 0
 		)
 	}

--- a/src/core/controller/models/refreshOpenRouterModels.ts
+++ b/src/core/controller/models/refreshOpenRouterModels.ts
@@ -6,7 +6,12 @@ import axios from "axios"
 import cloneDeep from "clone-deep"
 import fs from "fs/promises"
 import path from "path"
-import { CLAUDE_SONNET_4_1M_TIERS, clineMicrowaveAlphaModelInfo, openRouterClaudeSonnet41mModelId } from "@/shared/api"
+import {
+	CLAUDE_SONNET_1M_TIERS,
+	clineMicrowaveAlphaModelInfo,
+	openRouterClaudeSonnet41mModelId,
+	openRouterClaudeSonnet451mModelId,
+} from "@/shared/api"
 import { Controller } from ".."
 
 type OpenRouterSupportedParams =
@@ -109,6 +114,8 @@ export async function refreshOpenRouterModels(
 				})
 
 				switch (rawModel.id) {
+					case "anthropic/claude-sonnet-4.5":
+					case "anthropic/claude-4.5-sonnet":
 					case "anthropic/claude-sonnet-4":
 					case "anthropic/claude-3-7-sonnet":
 					case "anthropic/claude-3-7-sonnet:beta":
@@ -204,11 +211,14 @@ export async function refreshOpenRouterModels(
 				models[rawModel.id] = modelInfo
 
 				// add custom :1m model variant
-				if (rawModel.id === "anthropic/claude-sonnet-4") {
-					const claudeSonnet41mModelInfo = cloneDeep(modelInfo)
-					claudeSonnet41mModelInfo.contextWindow = 1_000_000 // limiting providers to those that support 1m context window
-					claudeSonnet41mModelInfo.tiers = CLAUDE_SONNET_4_1M_TIERS
-					models[openRouterClaudeSonnet41mModelId] = claudeSonnet41mModelInfo
+				if (rawModel.id === "anthropic/claude-sonnet-4" || rawModel.id === "anthropic/claude-sonnet-4.5") {
+					const claudeSonnet1mModelInfo = cloneDeep(modelInfo)
+					claudeSonnet1mModelInfo.contextWindow = 1_000_000 // limiting providers to those that support 1m context window
+					claudeSonnet1mModelInfo.tiers = CLAUDE_SONNET_1M_TIERS
+					// sonnet 4
+					models[openRouterClaudeSonnet41mModelId] = claudeSonnet1mModelInfo
+					// sonnet 4.5
+					models[openRouterClaudeSonnet451mModelId] = claudeSonnet1mModelInfo
 				}
 			}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -426,7 +426,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	// Register the command handlers
 	context.subscriptions.push(
-		vscode.commands.registerCommand("cline.addToChat", async (range?: vscode.Range, diagnostics?: vscode.Diagnostic[]) => {
+		vscode.commands.registerCommand("hai.addToChat", async (range?: vscode.Range, diagnostics?: vscode.Diagnostic[]) => {
 			const context = await getContextForCommand(range, diagnostics)
 			if (!context) {
 				return

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -214,8 +214,8 @@ export interface OpenAiCompatibleModelInfo extends ModelInfo {
 	isR1FormatRequired?: boolean
 }
 
-export const CLAUDE_SONNET_4_1M_SUFFIX = ":1m"
-export const CLAUDE_SONNET_4_1M_TIERS = [
+export const CLAUDE_SONNET_1M_SUFFIX = ":1m"
+export const CLAUDE_SONNET_1M_TIERS = [
 	{
 		contextWindow: 200000,
 		inputPrice: 3.0,
@@ -235,8 +235,39 @@ export const CLAUDE_SONNET_4_1M_TIERS = [
 // Anthropic
 // https://docs.anthropic.com/en/docs/about-claude/models // prices updated 2025-01-02
 export type AnthropicModelId = keyof typeof anthropicModels
-export const anthropicDefaultModelId: AnthropicModelId = "claude-sonnet-4-20250514"
+export const anthropicDefaultModelId: AnthropicModelId = "claude-sonnet-4-5-20250929"
 export const anthropicModels = {
+	"claude-sonnet-4-5-20250929": {
+		maxTokens: 8192,
+		contextWindow: 200_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 3.0,
+		outputPrice: 15.0,
+		cacheWritesPrice: 3.75,
+		cacheReadsPrice: 0.3,
+	},
+	"claude-sonnet-4-5-20250929:1m": {
+		maxTokens: 8192,
+		contextWindow: 1_000_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 3.0,
+		outputPrice: 15.0,
+		cacheWritesPrice: 3.75,
+		cacheReadsPrice: 0.3,
+		tiers: CLAUDE_SONNET_1M_TIERS,
+	},
+	"claude-sonnet-4-20250514": {
+		maxTokens: 8192,
+		contextWindow: 200_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 3.0,
+		outputPrice: 15.0,
+		cacheWritesPrice: 3.75,
+		cacheReadsPrice: 0.3,
+	},
 	"claude-sonnet-4-20250514:1m": {
 		maxTokens: 8192,
 		contextWindow: 1_000_000,
@@ -246,18 +277,7 @@ export const anthropicModels = {
 		outputPrice: 15.0,
 		cacheWritesPrice: 3.75,
 		cacheReadsPrice: 0.3,
-		tiers: CLAUDE_SONNET_4_1M_TIERS,
-	},
-	"claude-sonnet-4-20250514": {
-		maxTokens: 8192,
-		contextWindow: 200_000,
-		supportsImages: true,
-
-		supportsPromptCache: true,
-		inputPrice: 3.0,
-		outputPrice: 15.0,
-		cacheWritesPrice: 3.75,
-		cacheReadsPrice: 0.3,
+		tiers: CLAUDE_SONNET_1M_TIERS,
 	},
 	"claude-opus-4-1-20250805": {
 		maxTokens: 8192,
@@ -335,8 +355,23 @@ export const anthropicModels = {
 
 // Claude Code
 export type ClaudeCodeModelId = keyof typeof claudeCodeModels
-export const claudeCodeDefaultModelId: ClaudeCodeModelId = "claude-sonnet-4-20250514"
+export const claudeCodeDefaultModelId: ClaudeCodeModelId = "claude-sonnet-4-5-20250929"
 export const claudeCodeModels = {
+	sonnet: {
+		...anthropicModels["claude-sonnet-4-5-20250929"],
+		supportsImages: false,
+		supportsPromptCache: false,
+	},
+	opus: {
+		...anthropicModels["claude-opus-4-1-20250805"],
+		supportsImages: false,
+		supportsPromptCache: false,
+	},
+	"claude-sonnet-4-5-20250929": {
+		...anthropicModels["claude-sonnet-4-5-20250929"],
+		supportsImages: false,
+		supportsPromptCache: false,
+	},
 	"claude-sonnet-4-20250514": {
 		...anthropicModels["claude-sonnet-4-20250514"],
 		supportsImages: false,
@@ -357,11 +392,6 @@ export const claudeCodeModels = {
 		supportsImages: false,
 		supportsPromptCache: false,
 	},
-	"claude-3-5-sonnet-20241022": {
-		...anthropicModels["claude-3-5-sonnet-20241022"],
-		supportsImages: false,
-		supportsPromptCache: false,
-	},
 	"claude-3-5-haiku-20241022": {
 		...anthropicModels["claude-3-5-haiku-20241022"],
 		supportsImages: false,
@@ -374,7 +404,17 @@ export const claudeCodeModels = {
 export type BedrockModelId = keyof typeof bedrockModels
 export const bedrockDefaultModelId: BedrockModelId = "anthropic.claude-sonnet-4-20250514-v1:0"
 export const bedrockModels = {
-	"anthropic.claude-sonnet-4-20250514-v1:0:1m": {
+	"anthropic.claude-sonnet-4-5-20250929-v1:0": {
+		maxTokens: 8192,
+		contextWindow: 200_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 3.0,
+		outputPrice: 15.0,
+		cacheWritesPrice: 3.75,
+		cacheReadsPrice: 0.3,
+	},
+	"anthropic.claude-sonnet-4-5-20250929-v1:0:1m": {
 		maxTokens: 8192,
 		contextWindow: 1_000_000,
 		supportsImages: true,
@@ -383,7 +423,7 @@ export const bedrockModels = {
 		outputPrice: 15.0,
 		cacheWritesPrice: 3.75,
 		cacheReadsPrice: 0.3,
-		tiers: CLAUDE_SONNET_4_1M_TIERS,
+		tiers: CLAUDE_SONNET_1M_TIERS,
 	},
 	"anthropic.claude-sonnet-4-20250514-v1:0": {
 		maxTokens: 8192,
@@ -394,6 +434,17 @@ export const bedrockModels = {
 		outputPrice: 15.0,
 		cacheWritesPrice: 3.75,
 		cacheReadsPrice: 0.3,
+	},
+	"anthropic.claude-sonnet-4-20250514-v1:0:1m": {
+		maxTokens: 8192,
+		contextWindow: 1_000_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 3.0,
+		outputPrice: 15.0,
+		cacheWritesPrice: 3.75,
+		cacheReadsPrice: 0.3,
+		tiers: CLAUDE_SONNET_1M_TIERS,
 	},
 	"anthropic.claude-opus-4-20250514-v1:0": {
 		maxTokens: 8192,
@@ -553,8 +604,9 @@ export const bedrockModels = {
 
 // OpenRouter
 // https://openrouter.ai/models?order=newest&supported_parameters=tools
-export const openRouterDefaultModelId = "anthropic/claude-sonnet-4" // will always exist in openRouterModels
-export const openRouterClaudeSonnet41mModelId = `anthropic/claude-sonnet-4${CLAUDE_SONNET_4_1M_SUFFIX}`
+export const openRouterDefaultModelId = "anthropic/claude-sonnet-4.5" // will always exist in openRouterModels
+export const openRouterClaudeSonnet41mModelId = `anthropic/claude-sonnet-4${CLAUDE_SONNET_1M_SUFFIX}`
+export const openRouterClaudeSonnet451mModelId = `anthropic/claude-sonnet-4.5${CLAUDE_SONNET_1M_SUFFIX}`
 export const openRouterDefaultModelInfo: ModelInfo = {
 	maxTokens: 8192,
 	contextWindow: 1_000_000,
@@ -564,9 +616,8 @@ export const openRouterDefaultModelInfo: ModelInfo = {
 	outputPrice: 15.0,
 	cacheWritesPrice: 3.75,
 	cacheReadsPrice: 0.3,
-	tiers: CLAUDE_SONNET_4_1M_TIERS,
 	description:
-		"Claude Sonnet 4 delivers superior intelligence across coding, agentic search, and AI agent capabilities. It's a powerful choice for agentic coding, and can complete tasks across the entire software development lifecycle—from initial planning to bug fixes, maintenance to large refactors. It offers strong performance in both planning and solving for complex coding tasks, making it an ideal choice to power end-to-end software development processes.\n\nRead more in the [blog post here](https://www.anthropic.com/claude/sonnet)",
+		"Claude Sonnet 4.5 delivers superior intelligence across coding, agentic search, and AI agent capabilities. It's a powerful choice for agentic coding, and can complete tasks across the entire software development lifecycle—from initial planning to bug fixes, maintenance to large refactors. It offers strong performance in both planning and solving for complex coding tasks, making it an ideal choice to power end-to-end software development processes.\n\nRead more in the [blog post here](https://www.anthropic.com/claude/sonnet)",
 }
 
 // HAI custom model - sonic (same config as grok-4)
@@ -586,6 +637,16 @@ export const clineMicrowaveAlphaModelInfo: ModelInfo = {
 export type VertexModelId = keyof typeof vertexModels
 export const vertexDefaultModelId: VertexModelId = "claude-sonnet-4@20250514"
 export const vertexModels = {
+	"claude-sonnet-4-5@20250929": {
+		maxTokens: 8192,
+		contextWindow: 200_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 3.0,
+		outputPrice: 15.0,
+		cacheWritesPrice: 3.75,
+		cacheReadsPrice: 0.3,
+	},
 	"claude-sonnet-4@20250514": {
 		maxTokens: 8192,
 		contextWindow: 200_000,

--- a/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
+++ b/webview-ui/src/components/settings/OpenRouterModelPicker.tsx
@@ -46,7 +46,7 @@ export interface OpenRouterModelPickerProps {
 // Featured models for HAI provider
 const featuredModels = [
 	{
-		id: "anthropic/claude-sonnet-4",
+		id: "anthropic/claude-sonnet-4.5",
 		description: "Recommended for agentic coding in HAI",
 		label: "Best",
 	},
@@ -219,6 +219,7 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup, 
 	const showBudgetSlider = useMemo(() => {
 		return (
 			Object.entries(openRouterModels)?.some(([id, m]) => id === selectedModelId && m.thinkingConfig) ||
+			selectedModelId?.toLowerCase().includes("claude-sonnet-4.5") ||
 			selectedModelId?.toLowerCase().includes("claude-sonnet-4") ||
 			selectedModelId?.toLowerCase().includes("claude-opus-4.1") ||
 			selectedModelId?.toLowerCase().includes("claude-opus-4") ||
@@ -229,17 +230,17 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup, 
 	}, [selectedModelId])
 
 	// Check if the current model is Claude Sonnet 4 and determine the alternate variant
-	const claudeSonnet4Variant = useMemo(() => {
-		if (selectedModelId === "anthropic/claude-sonnet-4") {
+	const claudeSonnet45Variant = useMemo(() => {
+		if (selectedModelId === "anthropic/claude-sonnet-4.5") {
 			return {
-				current: "anthropic/claude-sonnet-4",
-				alternate: "anthropic/claude-sonnet-4:1m",
+				current: "anthropic/claude-sonnet-4.5",
+				alternate: "anthropic/claude-sonnet-4.5:1m",
 				linkText: "Switch to 1M context window model",
 			}
-		} else if (selectedModelId === "anthropic/claude-sonnet-4:1m") {
+		} else if (selectedModelId === "anthropic/claude-sonnet-4.5:1m") {
 			return {
-				current: "anthropic/claude-sonnet-4:1m",
-				alternate: "anthropic/claude-sonnet-4",
+				current: "anthropic/claude-sonnet-4.5:1m",
+				alternate: "anthropic/claude-sonnet-4.5",
 				linkText: "Switch to 200K context window model",
 			}
 		}
@@ -346,16 +347,16 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup, 
 					)}
 				</DropdownWrapper>
 
-				{claudeSonnet4Variant && (
+				{claudeSonnet45Variant && (
 					<div style={{ marginBottom: 2 }}>
 						<VSCodeLink
-							onClick={() => handleModelChange(claudeSonnet4Variant.alternate)}
+							onClick={() => handleModelChange(claudeSonnet45Variant.alternate)}
 							style={{
 								display: "inline",
 								fontSize: "10.5px",
 								color: "var(--vscode-textLink-foreground)",
 							}}>
-							{claudeSonnet4Variant.linkText}
+							{claudeSonnet45Variant.linkText}
 						</VSCodeLink>
 					</div>
 				)}
@@ -380,9 +381,9 @@ const OpenRouterModelPicker: React.FC<OpenRouterModelPickerProps> = ({ isPopup, 
 					</VSCodeLink>
 					If you're unsure which model to choose, HAI works best with{" "}
 					<VSCodeLink
-						onClick={() => handleModelChange("anthropic/claude-sonnet-4")}
+						onClick={() => handleModelChange("anthropic/claude-sonnet-4.5")}
 						style={{ display: "inline", fontSize: "inherit" }}>
-						anthropic/claude-sonnet-4.
+						anthropic/claude-sonnet-4.5.
 					</VSCodeLink>
 					You can also try searching "free" for no-cost options currently available.
 				</p>

--- a/webview-ui/src/components/settings/providers/AnthropicProvider.tsx
+++ b/webview-ui/src/components/settings/providers/AnthropicProvider.tsx
@@ -1,4 +1,4 @@
-import { anthropicModels, CLAUDE_SONNET_4_1M_SUFFIX } from "@shared/api"
+import { anthropicModels, CLAUDE_SONNET_1M_SUFFIX } from "@shared/api"
 import { Mode } from "@shared/storage/types"
 import { VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 import { useMemo } from "react"
@@ -15,10 +15,11 @@ import { useApiConfigurationHandlers } from "../utils/useApiConfigurationHandler
 export const SUPPORTED_ANTHROPIC_THINKING_MODELS = [
 	"claude-3-7-sonnet-20250219",
 	"claude-sonnet-4-20250514",
-	`claude-sonnet-4-20250514${CLAUDE_SONNET_4_1M_SUFFIX}`,
+	`claude-sonnet-4-20250514${CLAUDE_SONNET_1M_SUFFIX}`,
 	"claude-opus-4-20250514",
-	`claude-sonnet-4-20250514${CLAUDE_SONNET_4_1M_SUFFIX}`,
 	"claude-opus-4-1-20250805",
+	"claude-sonnet-4-5-20250929",
+	`claude-sonnet-4-5-20250929${CLAUDE_SONNET_1M_SUFFIX}`,
 ]
 
 /**
@@ -41,18 +42,18 @@ export const AnthropicProvider = ({ showModelOptions, isPopup, currentMode }: An
 	const { selectedModelId, selectedModelInfo } = normalizeApiConfiguration(apiConfiguration, currentMode)
 
 	// Check if the current model is Claude Sonnet 4 and determine the alternate variant
-	const claudeSonnet4Variant = useMemo(() => {
-		const SONNET_4_MODEL_ID = "claude-sonnet-4-20250514"
-		if (selectedModelId === SONNET_4_MODEL_ID) {
+	const claudeSonnet45Variant = useMemo(() => {
+		const SONNET_4_5_MODEL_ID = "claude-sonnet-4-5-20250929"
+		if (selectedModelId === SONNET_4_5_MODEL_ID) {
 			return {
-				current: SONNET_4_MODEL_ID,
-				alternate: `${SONNET_4_MODEL_ID}${CLAUDE_SONNET_4_1M_SUFFIX}`,
+				current: SONNET_4_5_MODEL_ID,
+				alternate: `${SONNET_4_5_MODEL_ID}${CLAUDE_SONNET_1M_SUFFIX}`,
 				linkText: "Switch to 1M context window model",
 			}
-		} else if (selectedModelId === `${SONNET_4_MODEL_ID}${CLAUDE_SONNET_4_1M_SUFFIX}`) {
+		} else if (selectedModelId === `${SONNET_4_5_MODEL_ID}${CLAUDE_SONNET_1M_SUFFIX}`) {
 			return {
-				current: `${SONNET_4_MODEL_ID}${CLAUDE_SONNET_4_1M_SUFFIX}`,
-				alternate: SONNET_4_MODEL_ID,
+				current: `${SONNET_4_5_MODEL_ID}${CLAUDE_SONNET_1M_SUFFIX}`,
+				alternate: SONNET_4_5_MODEL_ID,
 				linkText: "Switch to 200K context window model",
 			}
 		}
@@ -90,13 +91,13 @@ export const AnthropicProvider = ({ showModelOptions, isPopup, currentMode }: An
 						selectedModelId={selectedModelId}
 					/>
 
-					{claudeSonnet4Variant && (
+					{claudeSonnet45Variant && (
 						<div style={{ marginBottom: 2 }}>
 							<VSCodeLink
 								onClick={() =>
 									handleModeFieldChange(
 										{ plan: "planModeApiModelId", act: "actModeApiModelId" },
-										claudeSonnet4Variant.alternate,
+										claudeSonnet45Variant.alternate,
 										currentMode,
 									)
 								}
@@ -105,7 +106,7 @@ export const AnthropicProvider = ({ showModelOptions, isPopup, currentMode }: An
 									fontSize: "10.5px",
 									color: "var(--vscode-textLink-foreground)",
 								}}>
-								{claudeSonnet4Variant.linkText}
+								{claudeSonnet45Variant.linkText}
 							</VSCodeLink>
 						</div>
 					)}

--- a/webview-ui/src/components/settings/providers/BedrockProvider.tsx
+++ b/webview-ui/src/components/settings/providers/BedrockProvider.tsx
@@ -1,4 +1,4 @@
-import { bedrockDefaultModelId, bedrockModels, CLAUDE_SONNET_4_1M_SUFFIX } from "@shared/api"
+import { bedrockDefaultModelId, bedrockModels, CLAUDE_SONNET_1M_SUFFIX } from "@shared/api"
 import { Mode } from "@shared/storage/types"
 import { VSCodeCheckbox, VSCodeDropdown, VSCodeOption, VSCodeRadio, VSCodeRadioGroup } from "@vscode/webview-ui-toolkit/react"
 import { useState } from "react"
@@ -21,7 +21,7 @@ interface BedrockProviderProps {
 
 export const BedrockProvider = ({ showModelOptions, isPopup, currentMode }: BedrockProviderProps) => {
 	const { apiConfiguration } = useExtensionState()
-	const { handleFieldChange, handleFieldsChange, handleModeFieldChange, handleModeFieldsChange } = useApiConfigurationHandlers()
+	const { handleFieldChange, handleModeFieldChange, handleModeFieldsChange } = useApiConfigurationHandlers()
 
 	const { selectedModelId, selectedModelInfo } = normalizeApiConfiguration(apiConfiguration, currentMode)
 	const modeFields = getModeSpecificFields(apiConfiguration, currentMode)
@@ -108,7 +108,7 @@ export const BedrockProvider = ({ showModelOptions, isPopup, currentMode }: Bedr
 					{/* The user will have to choose a region that supports the model they use, but this shouldn't be a problem since they'd have to request access for it in that region in the first place. */}
 					<VSCodeOption value="us-east-1">us-east-1</VSCodeOption>
 					<VSCodeOption value="us-east-2">us-east-2</VSCodeOption>
-					{/* <VSCodeOption value="us-west-1">us-west-1</VSCodeOption> */}
+					<VSCodeOption value="us-west-1">us-west-1</VSCodeOption>
 					<VSCodeOption value="us-west-2">us-west-2</VSCodeOption>
 					{/* <VSCodeOption value="af-south-1">af-south-1</VSCodeOption> */}
 					{/* <VSCodeOption value="ap-east-1">ap-east-1</VSCodeOption> */}
@@ -304,7 +304,9 @@ export const BedrockProvider = ({ showModelOptions, isPopup, currentMode }: Bedr
 
 					{(selectedModelId === "anthropic.claude-3-7-sonnet-20250219-v1:0" ||
 						selectedModelId === "anthropic.claude-sonnet-4-20250514-v1:0" ||
-						selectedModelId === `anthropic.claude-sonnet-4-20250514-v1:0${CLAUDE_SONNET_4_1M_SUFFIX}` ||
+						selectedModelId === "anthropic.claude-sonnet-4-5-20250929-v1:0" ||
+						selectedModelId === `anthropic.claude-sonnet-4-20250514-v1:0${CLAUDE_SONNET_1M_SUFFIX}` ||
+						selectedModelId === `anthropic.claude-sonnet-4-5-20250929-v1:0${CLAUDE_SONNET_1M_SUFFIX}` ||
 						selectedModelId === "anthropic.claude-opus-4-1-20250805-v1:0" ||
 						selectedModelId === "anthropic.claude-opus-4-20250514-v1:0" ||
 						(modeFields.awsBedrockCustomSelected &&
@@ -312,8 +314,13 @@ export const BedrockProvider = ({ showModelOptions, isPopup, currentMode }: Bedr
 						(modeFields.awsBedrockCustomSelected &&
 							modeFields.awsBedrockCustomModelBaseId === "anthropic.claude-sonnet-4-20250514-v1:0") ||
 						(modeFields.awsBedrockCustomSelected &&
+							modeFields.awsBedrockCustomModelBaseId === "anthropic.claude-sonnet-4-5-20250929-v1:0") ||
+						(modeFields.awsBedrockCustomSelected &&
 							modeFields.awsBedrockCustomModelBaseId ===
-								`anthropic.claude-sonnet-4-20250514-v1:0${CLAUDE_SONNET_4_1M_SUFFIX}`) ||
+								`anthropic.claude-sonnet-4-20250514-v1:0${CLAUDE_SONNET_1M_SUFFIX}`) ||
+						(modeFields.awsBedrockCustomSelected &&
+							modeFields.awsBedrockCustomModelBaseId ===
+								`anthropic.claude-sonnet-4-5-20250929-v1:0${CLAUDE_SONNET_1M_SUFFIX}`) ||
 						(modeFields.awsBedrockCustomSelected &&
 							modeFields.awsBedrockCustomModelBaseId === "anthropic.claude-opus-4-1-20250805-v1:0") ||
 						(modeFields.awsBedrockCustomSelected &&

--- a/webview-ui/src/components/settings/providers/ClaudeCodeProvider.tsx
+++ b/webview-ui/src/components/settings/providers/ClaudeCodeProvider.tsx
@@ -63,6 +63,18 @@ export const ClaudeCodeProvider = ({ showModelOptions, isPopup, currentMode }: C
 						selectedModelId={selectedModelId}
 					/>
 
+					{(selectedModelId === "sonnet" || selectedModelId === "opus") && (
+						<p
+							style={{
+								fontSize: "12px",
+								marginBottom: 2,
+								marginTop: 2,
+								color: "var(--vscode-descriptionForeground)",
+							}}>
+							Use the latest version of {selectedModelId} by default.
+						</p>
+					)}
+
 					{SUPPORTED_ANTHROPIC_THINKING_MODELS.includes(selectedModelId) && (
 						<ThinkingBudgetSlider currentMode={currentMode} maxBudget={selectedModelInfo.thinkingConfig?.maxBudget} />
 					)}


### PR DESCRIPTION
### Description

- Enhanced support for Claude Sonnet 4.5, extending its maximum context window to 1 million tokens and enabling tiered pricing for more flexible usage models.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] ♻️ Refactor Changes
-   [ ] 💅 Cosmetic Changes
-   [x] 📚 Documentation update
-   [ ] 🏃 Workflow Changes

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have created a changeset using `npm run changeset` (required for user-facing changes)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/cline-based-code-generator/blob/main/CONTRIBUTING.md)